### PR TITLE
Generic behavior traits for the EA Hostage captain.

### DIFF
--- a/scripts/escape_mission.lua
+++ b/scripts/escape_mission.lua
@@ -1,0 +1,18 @@
+
+
+function fixNoPatrolFacing( sim )
+	for i,unit in pairs( sim:getAllUnits() ) do
+		if unit:getTraits().mm_fixnopatrolfacing then
+			unit:getTraits().patrolPath[1].facing = unit:getFacing()
+		end
+	end
+end
+
+
+function init( scriptMgr, sim )
+	fixNoPatrolFacing( sim )
+end
+
+return {
+	init = init,
+}

--- a/scripts/idle.lua
+++ b/scripts/idle.lua
@@ -1,0 +1,11 @@
+local IdleSituation = include("sim/btree/situations/idle")
+
+local oldGeneratePatrolPath = IdleSituation.generatePatrolPath
+
+function IdleSituation:generatePatrolPath( unit, x0, y0, noPatrolCheck )
+	assert( unit:getBrain():getSituation() == self )
+
+	if not unit:getTraits().mm_nopatrolchange then
+		oldGeneratePatrolPath( self, unit, x0, y0, noPatrolCheck )
+	end
+end

--- a/scripts/missions/ea_hostage.lua
+++ b/scripts/missions/ea_hostage.lua
@@ -551,12 +551,6 @@ local function createManacles(sim)
 	sim:emitSound(simdefs.SOUND_ITEM_PUTDOWN, cell.x, cell.y)
 end
 
-local function fixCaptainPath(sim)
-  -- SimEngine:init doesn't save initial facing when it generates the patrolPath for nopatrol=true.
-  local captain = mission_util.findUnitByTag(sim, "MM_captain")
-  captain:getTraits().patrolPath[1].facing = captain:getFacing()
-end
-
 local function startPhase( script, sim )
 
 	sim:addObjective( STRINGS.MOREMISSIONS_HOSTAGE.MISSIONS.HOSTAGE.OBJECTIVE_FIND_HOSTAGE, "hostage_1" )
@@ -688,7 +682,6 @@ function hostage_mission:init( scriptMgr, sim )
 				end
 			end )
 			
-	fixCaptainPath(sim)
 	scriptMgr:addHook( "HOSTAGE", startPhase )
 
 

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -10,7 +10,7 @@ local simquery = include ( "sim/simquery" )
 local default_missiontags = array.copy(serverdefs.ESCAPE_MISSION_TAGS)
 
 local function earlyInit( modApi )
-	modApi.requirements = { "Contingency Plan", "Sim Constructor", "Function Library", "Items Evacuation", "New Items And Augments" }
+	modApi.requirements = { "Contingency Plan", "Sim Constructor", "Function Library", "Advanced Guard Protocol", "Items Evacuation", "New Items And Augments" }
 end
 
 local function init( modApi )
@@ -71,6 +71,7 @@ local function init( modApi )
 		end
 	end
 	
+	include( scriptPath .. "/idle" )
 	include( scriptPath .. "/unitrig" )
 
 end

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -162,8 +162,8 @@ local function load( modApi, options, params )
 	-- local corpworldPrefabs = include( scriptPath .. "/prefabs/corpworld/prefabt" )
 	-- modApi:addWorldPrefabt(scriptPath, "corpworld", corpworldPrefabs)
 
-	-- local escape_mission = include( scriptPath .. "/escape_mission" )
-	-- modApi:addEscapeScripts(escape_mission)
+	local escape_mission = include( scriptPath .. "/escape_mission" )
+	modApi:addEscapeScripts(escape_mission)
 
 	-- modApi:setCampaignEvent_setCampaignParam(nil,"contingency_plan",true)
 

--- a/scripts/prefabs/shared/hostage_1.lua
+++ b/scripts/prefabs/shared/hostage_1.lua
@@ -636,7 +636,7 @@ local units =
                 unitData =
                 {
                     facing = 4,
-		    traits={nopatrol=true},
+		    traits={nopatrol=true,mm_nopatrolchange=true},
                    tags =
                    {
                        "MM_captain",

--- a/scripts/prefabs/shared/hostage_1.lua
+++ b/scripts/prefabs/shared/hostage_1.lua
@@ -636,7 +636,7 @@ local units =
                 unitData =
                 {
                     facing = 4,
-		    traits={nopatrol=true,mm_nopatrolchange=true},
+		    traits={nopatrol=true,mm_fixnopatrolfacing=true,mm_nopatrolchange=true},
                    tags =
                    {
                        "MM_captain",


### PR DESCRIPTION
* `mm_fixnopatrolfacing` fixes a stationary guard placed with the `nopatrol` trait.
* `mm_nopatrolchange` causes a guard to ignore patrol changes (DLC extended campaign alarm level, exec terminals escalation, etc) if a script needs the guard to stick around until alerted. This can also be reasonably applied to patrolling guards.