### PR TITLE
Door-lock behavior for assassination mission

### DIFF
--- a/scripts/btree/actions.lua
+++ b/scripts/btree/actions.lua
@@ -23,13 +23,20 @@ function Actions.mmRequestNewPanicTarget( sim, unit )
 
 	local x0,y0 = unit:getLocation()
 	local cells = sim:getCells( "saferoom" )
+	local doorCell = sim:getCells( "saferoom_door" ) and sim:getCells( "saferoom_door" )[1]
 	local targetCell = nil
 
 	if cells then
 		cells = util.tdupe( cells )
 		local function isInvalidHuntCell(c)
-			-- Want open cells not near the CEO's current position
-			return c.impass > 0 or (math.abs(c.x - x0) <= 2 and math.abs(c.y - y0) <= 2)
+			return (
+				-- open cells
+				c.impass > 0
+				-- not near the CEO's current position
+				or (math.abs(c.x - x0) <= 2 and math.abs(c.y - y0) <= 2)
+				-- not at the door (don't accidentally open the door to peek)
+				or (doorCell and c.x == doorCell.x and c.y == doorCell.y)
+			)
 		end
 		array.removeIf( cells, isInvalidHuntCell )
 

--- a/scripts/engine.lua
+++ b/scripts/engine.lua
@@ -1,0 +1,35 @@
+local simdefs = include( "sim/simdefs" )
+local simengine = include( "sim/engine" )
+local simquery = include( "sim/simquery" )
+
+local oldModifyExit = simengine.modifyExit
+
+function simengine:modifyExit( cell, dir, exitOp, unit, stealth, ... )
+	local exit = cell.exits[dir]
+	assert( exit )
+
+	if exitOp == simdefs.EXITOP_OPEN and exit.locked and unit and simquery._canUseLockedExit( unit, exitOp, exit ) == 'mm_npckey' then
+		-- Unlock, but set to automatically close and lock
+		local reverseExit = exit.cell.exits[simquery.getReverseDirection( dir )]
+		exit.locked, reverseExit.locked = nil, nil
+		exit.closeEndTurn, reverseExit.closeEndTurn = true, true
+		exit.lockEndTurn, reverseExit.lockEndTurn = true, true
+		exit.temporaryCloseEndTurn, reverseExit.temporaryCloseEndTurn = true, true
+		exit.temporaryLockEndTurn, reverseExit.temporaryLockEndTurn = true, true
+	end
+
+	oldModifyExit( self, cell, dir, exitOp, unit, stealth, ... )
+
+	if exitOp == simdefs.EXITOP_CLOSE and exit.temporaryLockEndTurn then
+		local reverseExit = exit.cell.exits[simquery.getReverseDirection( dir )]
+		assert( exit.closed and reverseExit.closed )
+		-- Lock and clear the the temporary flags
+		exit.locked, reverseExit.locked = true, true
+		exit.closeEndTurn, reverseExit.closeEndTurn = nil, nil
+		exit.lockEndTurn, reverseExit.lockEndTurn = nil, nil
+		exit.temporaryCloseEndTurn, reverseExit.temporaryCloseEndTurn = nil, nil
+		exit.temporaryLockEndTurn, reverseExit.temporaryLockEndTurn = nil, nil
+
+		self:dispatchEvent( simdefs.EV_EXIT_MODIFIED, { cell = cell, dir = dir, exitOp = simdefs.EXITOP_LOCK } )
+	end
+end

--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -90,10 +90,10 @@ local BODYGUARD_KO =
 	end,
 }
 local function canUseSaferoomKey( unit )
-	return unit:getPlayerOwner() and unit:getPlayerOwner():isPC() and unit:ownsAbility("moveBody")
+	return unit:getPlayerOwner() and unit:getPlayerOwner():isPC() and not unit:getTraits().isDrone
 end
 local function isSaferoomKey( unit )
-	return unit:isDown() and (unit:getTraits().isGuard and not unit:getTraits().isDrone or unit:getTraits().iscorpse and not unit:getTraits().wasDrone)
+	return unit:isDown() and (unit:hasTag("assassination") or unit:hasTag("bodyguard"))
 end
 local PC_UNLOCK_SAFEROOM =
 {

--- a/scripts/missions/ea_hostage.lua
+++ b/scripts/missions/ea_hostage.lua
@@ -608,7 +608,7 @@ local function startPhase( script, sim )
 	--updateVitalStatus(script, sim, true)
 
 	script:queue( { body=STRINGS.MOREMISSIONS_HOSTAGE.MISSIONS.HOSTAGE.HOSTAGE_CONVO1, 
-					header=STRINGS.MOREMISSIONS.AGENTS.EA_HOSTAGE.NAME,, type="enemyMessage", 
+					header=STRINGS.MOREMISSIONS.AGENTS.EA_HOSTAGE.NAME, type="enemyMessage",
 					profileAnim="portraits/portrait_animation_template",
 					profileBuild="portraits/courier_face",
 				} )
@@ -618,7 +618,7 @@ local function startPhase( script, sim )
 	--script:queue( 160 )	
 	script:queue( { type="clearOperatorMessage" } )
 	script:queue( { body=STRINGS.MOREMISSIONS_HOSTAGE.MISSIONS.HOSTAGE.HOSTAGE_CONVO2, 
-					header=STRINGS.MOREMISSIONS.AGENTS.EA_HOSTAGE.NAME,, type="enemyMessage", 
+					header=STRINGS.MOREMISSIONS.AGENTS.EA_HOSTAGE.NAME, type="enemyMessage",
 					profileAnim="portraits/portrait_animation_template",
 					profileBuild="portraits/courier_face",
 				} )

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -88,6 +88,8 @@ local function init( modApi )
 		oldInit( self, params, levelData, ... )	
 	end	
   
+	include( scriptPath .. "/simquery" )
+	include( scriptPath .. "/engine" )
 	include( scriptPath .. "/idle" )
 	include( scriptPath .. "/unitrig" )
 

--- a/scripts/simquery.lua
+++ b/scripts/simquery.lua
@@ -1,0 +1,49 @@
+local binops = include( "modules/binary_ops" )
+local simdefs = include( "sim/simdefs" )
+local simquery = include( "sim/simquery" )
+
+-- This isn't defined by vanilla, but may be provided/extended by other mods
+local oldCanUseLockedExit = simquery._canUseLockedExit
+
+-- If truthy, override the op-specific checks from canModifyExit to bypass the normal locked checks.
+-- This method assumes responsibility for any op-specific conditions that need to still apply (e.g. closed) before returning true.
+--
+-- Generic failure modes (e.g. dragging a body) will cause canModifyExit to fail with corresponding error messages, regardless of this call.
+--
+-- Return a mod-specific value to ease identifying which mod's override to use in simengine:modifyExit.
+function simquery._canUseLockedExit( unit, exitOp, exit )
+	local res = false
+	if oldCanUseLockedExit then
+		res = oldCanUseLockedExit( unit, exit ) 
+	end
+
+	if (not res
+		and (exitOp == simdefs.EXITOP_OPEN or exitOp == simdefs.EXITOP_UNLOCK)
+		and exit.closed and exit.locked
+		and unit and unit:isNPC() and unit:getTraits().npcPassiveKeybits
+	) then
+		if binops.b_and( exit.keybits, unit:getTraits().npcPassiveKeybits ) ~= 0 then
+			res = 'mm_npckey'
+		end
+	end
+
+	return res
+end
+
+if not oldCanUseLockedExit then
+	-- Wrap canModifyExit to check _canUseLockedExit
+
+	local oldCanModifyExit = simquery.canModifyExit
+
+	function simquery.canModifyExit( unit, exitOp, cell, dir, ... )
+		local exit = cell.exits[ dir ]
+		assert( exit and exit.door )
+
+		if unit and simquery._canUseLockedExit( unit, exitOp, exit ) then
+			-- Only check non-op-specific conditions
+			return oldCanModifyExit( unit, 'NOOP', cell, dir, ... )
+		end
+
+		return oldCanModifyExit( unit, exitOp, cell, dir, ... )
+	end
+end


### PR DESCRIPTION
The CEO is allowed to walk through the saferoom door freely, even when locked.

If a player agent drags either the CEO or bodyguard up to the saferoom door, it is permanently unlocked.