### PR TITLE
Assassination brain tweaks

### DIFF
--- a/scripts/btree/actions.lua
+++ b/scripts/btree/actions.lua
@@ -4,6 +4,7 @@ local simdefs = include("sim/simdefs")
 local simquery = include("sim/simquery")
 local btree = include("sim/btree/btree")
 local Actions = include("sim/btree/actions")
+local Conditions = include("sim/btree/conditions")
 
 local function interestOutsideOfSaferoom( sim, interest )
 	local cell = sim:getCell( interest.x, interest.y )
@@ -83,7 +84,10 @@ end
 function Actions.mmFaceInterest( sim, unit )
 	local interest = unit:getBrain():getInterest()
 	if interest and not interest.mmFaced and unit:canReact() then
-		unit:turnToFace(interest.x, interest.y)
+		-- Skip turning if unarmed and losttarget. Otherwise we keep turning back while trying to flee.
+		if (not interest.reason == simdefs.REASON_LOSTTARGET) or Conditions.mmIsArmed( sim, unit ) then
+			unit:turnToFace(interest.x, interest.y)
+		end
 		interest.mmFaced = true
 	end
 

--- a/scripts/btree/actions.lua
+++ b/scripts/btree/actions.lua
@@ -33,8 +33,6 @@ function Actions.mmArmVip( sim, unit )
 	unit:getTraits().mmSearchedVipSafe = true
 	unit:getTraits().vip = false
 
-	sim:processReactions( unit )
-
 	return simdefs.BSTATE_COMPLETE
 end
 

--- a/scripts/btree/bountytargetbrain.lua
+++ b/scripts/btree/bountytargetbrain.lua
@@ -68,8 +68,8 @@ local function PanicFlee()
 	{
 		btree.Condition(conditions.IsAlerted),
 		actions.mmMoveToSafetyPoint(),
-		btree.Action(actions.DoLookAround),
 		btree.Action(actions.mmArmVip),
+		btree.Action(actions.DoLookAround),
 		btree.Action(actions.Cower), -- Also removes interests, if present.
 		btree.Action(actions.mmRequestNewPanicTarget), -- Begin hunting around the room.
 	})

--- a/scripts/btree/bountytargetbrain.lua
+++ b/scripts/btree/bountytargetbrain.lua
@@ -24,17 +24,11 @@ local function PanicCombat()
 		btree.Condition(conditions.mmHasSearchedVipSafe),
 		btree.Condition(conditions.HasTarget),
 		btree.Action(actions.ReactToTarget),
-		btree.Selector("Engage",
-		{
-			btree.Sequence("WithWeapon",
-			{
-				btree.Condition(conditions.mmIsArmed),
-				btree.Condition(conditions.CanShootTarget),
-				btree.Action(actions.ShootAtTarget),
-			}),
-			-- If the target's weapon has been stolen, just point and shout.
-			btree.Action(actions.WatchTarget),
-		}),
+
+		btree.Condition(conditions.mmIsArmed),
+		btree.Condition(conditions.CanShootTarget),
+		-- Otherwise, fall through to PanicFlee.
+		btree.Action(actions.ShootAtTarget),
 	})
 end
 
@@ -47,7 +41,12 @@ local function PanicHunt()
 		btree.Condition(conditions.HasInterest),
 		btree.Action(actions.ReactToInterest),
 		btree.Action(actions.mmFaceInterest),
-		btree.Condition(conditions.mmInterestInSaferoom),
+		btree.Selector("CanInvestigate",
+		{
+			btree.Condition(conditions.mmInterestIsSelfPanic),
+			btree.Condition(conditions.mmIsArmedAndInterestInSaferoom),
+			-- Otherwise, fall through to PanicFlee.
+		}),
 		actions.MoveToInterest(),
 		btree.Action(actions.MarkInterestInvestigated),
 		btree.Action(actions.DoLookAround),

--- a/scripts/btree/conditions.lua
+++ b/scripts/btree/conditions.lua
@@ -1,3 +1,4 @@
+local simdefs = include("sim/simdefs")
 local simquery = include("sim/simquery")
 local Conditions = include("sim/btree/conditions")
 
@@ -16,4 +17,13 @@ function Conditions.mmInterestInSaferoom( sim, unit )
 		return simquery.cellHasTag( sim, cell, "saferoom" )
 	end
 	return false
+end
+
+function Conditions.mmIsArmedAndInterestInSaferoom( sim, unit )
+	return Conditions.mmIsArmed( sim, unit ) and Conditions.mmInterestInSaferoom( sim, unit )
+end
+
+function Conditions.mmInterestIsSelfPanic( sim, unit )
+	local interest = unit:getBrain():getInterest()
+	return interest and (interest.sourceUnit == unit) and (interest.reason == simdefs.REASON_HUNTING)
 end


### PR DESCRIPTION
* When panicked and unarmed, the CEO will react to distractions by fleeing (instead of trying to investigate, as he would when armed)
* Perform the loot-and-arm code before the peek when he first reaches the safe. This behaves better if his peek is interrupted by finding something.

Note: The animations don't play correctly in the latter case. The looting animation stops partway through and the peek animation never plays. Sim behavior is correct.