### PR TITLE
Add CI for automatically building the mod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo chmod +x exampleapi/KWAD\ builder/bin/linux/builder
           echo KWAD_BUILDER="./exampleapi/KWAD\ builder/bin/linux/builder" > makeconfig.mk
-          echo INSTALL_PATH="./install" > makeconfig.mk
+          echo INSTALL_PATH="./install" >> makeconfig.mk
           make install
         
       - name: Upload a Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+          
+      - name: Download Example API from steam workshop
+        run: |
+          wget -q https://steamusercontent-a.akamaihd.net/ugc/358399162719791713/17B6973C6F60561466E081AEE0EF35ABC2FB19F2/ -O mod_publish_data_file.zip
+          
+      - name: Unzip Example API
+        run:  unzip -qq ./mod_publish_data_file.zip -d ./exampleapi || echo "Suppressing unzip errors"
+     
+      - name: Make the mod using the given makefile
+        run: |
+          sudo chmod +x exampleapi/KWAD\ builder/bin/linux/builder
+          echo KWAD_BUILDER="./exampleapi/KWAD\ builder/bin/linux/builder" > makeconfig.mk
+          make
+        
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          name: "MoreMissions"
+          path: out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,16 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
           
-      - name: Download Example API from steam workshop
+      - name: Download KWAD Builder
         run: |
-          wget -q https://steamusercontent-a.akamaihd.net/ugc/358399162719791713/17B6973C6F60561466E081AEE0EF35ABC2FB19F2/ -O mod_publish_data_file.zip
+          wget -q https://cdn.discordapp.com/attachments/313015598789427202/565295702540812298/KWAD_builder.zip -O KWAD_builder.zip
           
       - name: Unzip Example API
-        run:  unzip -qq ./mod_publish_data_file.zip -d ./exampleapi || echo "Suppressing unzip errors"
+        run:  unzip -qq ./KWAD_builder.zip -d ./builder || echo "Suppressing unzip errors"
      
       - name: Make the mod using the given makefile
         run: |
-          sudo chmod +x exampleapi/KWAD\ builder/bin/linux/builder
+          sudo chmod +x builder/bin/linux/builder
           echo KWAD_BUILDER="./exampleapi/KWAD\ builder/bin/linux/builder" > makeconfig.mk
           echo INSTALL_PATH="./install" >> makeconfig.mk
           make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Make the mod using the given makefile
         run: |
           sudo chmod +x builder/bin/linux/builder
-          echo KWAD_BUILDER="./exampleapi/KWAD\ builder/bin/linux/builder" > makeconfig.mk
+          echo KWAD_BUILDER=./builder/bin/linux/builder > makeconfig.mk
           echo INSTALL_PATH="./install" >> makeconfig.mk
           make install
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,11 @@ jobs:
         run: |
           sudo chmod +x exampleapi/KWAD\ builder/bin/linux/builder
           echo KWAD_BUILDER="./exampleapi/KWAD\ builder/bin/linux/builder" > makeconfig.mk
-          make
+          echo INSTALL_PATH="./install" > makeconfig.mk
+          make install
         
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2.2.3
         with:
           name: "MoreMissions"
-          path: out
+          path: install


### PR DESCRIPTION
I wrote a github action that will automatically download the Example API mod from the steam workshop and use it in conjunction with the provided Makefile in the repository to build a working mod zip. 

Potential things to improve:

- Add caching to the KWAD Builder download so the builder itself and its intermediate cache can be saved between builds
- Host the KWAD builder download somewhere else so the steam workshop download isn't needed.