### PR TITLE
Make the camera DB sightable in Mole mission

### DIFF
--- a/scripts/missions/mole_insertion.lua
+++ b/scripts/missions/mole_insertion.lua
@@ -689,7 +689,8 @@ local function despawnRedundantCameraDB(sim)
 		if unit:getUnitData().id == "camera_core" then
 			table.insert(cameraDBs, unit)
 			unit:getTraits().MM_camera_core = true
-			unit:addTag("MM_camera_core") --this doesn't work?!!!
+			unit:getTraits().sightable = true --required for triggering on unit appeared
+			unit:addTag("MM_camera_core")
 			unit:giveAbility("MM_scrubcameradb") --ability that allows witness scrubbing
 			local daemonList = sim:getIcePrograms()
 			if daemonList:getCount() > 0 then


### PR DESCRIPTION
Required for the mission script (tag and dialog line telling the player this may be useful) to fire

Fixes #28