### PR TITLE
Heat Signature tab fix

### DIFF
--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -282,6 +282,58 @@ local function doUnlockSaferoom( sim, agent )
 	end
 end
 
+--Ended up being loosely based on followHeatSig from mission_ceo_office (CFO) -SLF
+local function followHeatSig( script, sim )
+	for _, unit in pairs( sim:getNPC():getUnits() ) do
+		if unit:getTraits().MM_bounty_target then
+			ceo = unit
+		end
+	end
+
+	ceo:createTab( STRINGS.MISSIONS.UTIL.HEAT_SIGNATURE_DETECTED, "" )
+	local x, y = ceo:getLocation()
+	script:queue( { type="pan", x=x, y=y } )
+
+	while true do
+		local ev, triggerData = script:waitFor( 
+			{ 	trigger = simdefs.TRG_UNIT_WARP,
+		    	fn = function( sim, triggerData )
+			    	if triggerData.unit and triggerData.unit:isNPC() and triggerData.unit:getTraits().dynamicImpass then
+			    		if triggerData.unit == ceo then
+			    			--log:write("[MM] [SLFTEST] Update -- MOVEMENT")
+			    			return sim:getCurrentPlayer() == sim:getNPC()
+			    		end
+			    	end
+			    end }, 
+			{	trigger = simdefs.TRG_NEW_INTEREST,
+				fn = function( sim, triggerData )
+					if triggerData.unit == ceo then
+						--log:write("[MM] [SLFTEST] Update -- ASSIGNED INTEREST POINT")
+						return true
+					end
+				end }, 
+			{ 	trigger = simdefs.TRG_UNIT_NEWINTEREST,
+			 	fn = function( sim, triggerData )
+					if triggerData.unit == ceo then
+						--log:write("[MM] [SLFTEST] Update -- UNIT INTEREST POINT")
+						return true
+					end
+				end }, 
+			{ 	trigger = simdefs.TRG_START_TURN,
+				fn = function( sim, triggerData )
+					--log:write("[MM] [SLFTEST] Update -- TURN START")
+					--by the way, if the target was distracted, then returns to idling, that happens AFTER start of turn
+					--there's a special append for that in modinit
+					return true
+				end	}
+		)
+		ceo:destroyTab()
+		ceo:createTab( STRINGS.MISSIONS.UTIL.HEAT_SIGNATURE_DETECTED, "" )
+		local x, y = ceo:getLocation()
+		script:queue( { type="pan", x=x, y=y } )
+	end
+end
+
 ----
 -- Script hooks
 
@@ -297,6 +349,10 @@ local function playerSeesCeo( script, sim, mission )
 	if ceo:getTraits().iscorpse then
 		report = SCRIPTS.INGAME.ASSASSINATION.AFTERMATH
 		mission.reportedCeoKilled = true
+		if mission.reportedCeoSeen == true then
+			script:removeHook( followHeatSig )
+			ceo:getTraits().MM_bounty_target_spotted = nil
+		end
 		mission.reportedCeoSeen = true
 	elseif ceo:isKO() then
 		sim:addObjective( STRINGS.MOREMISSIONS.MISSIONS.ASSASSINATION.OBJ_KILL, "kill" )
@@ -308,7 +364,8 @@ local function playerSeesCeo( script, sim, mission )
 		mission.reportedCeoSeen = true
 
 		--create that big white arrow pointing to the target
-		ceo:createTab( STRINGS.MISSIONS.UTIL.HEAT_SIGNATURE_DETECTED, "" )
+		script:addHook( followHeatSig )
+		ceo:getTraits().MM_bounty_target_spotted = true --checked in a modinit append
 	end
 
 	local x,y = ceo:getLocation()

--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -328,6 +328,9 @@ local function followHeatSig( script, sim )
 				end	}
 		)
 		ceo:destroyTab()
+		if ceo:getTraits().iscorpse then 
+			break
+		end
 		ceo:createTab( STRINGS.MISSIONS.UTIL.HEAT_SIGNATURE_DETECTED, "" )
 		local x, y = ceo:getLocation()
 		script:queue( { type="pan", x=x, y=y } )

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -91,6 +91,24 @@ local function init( modApi )
 		oldInit( self, params, levelData, ... )	
 	end	
 
+	--Keeps the "heat signature detected" label when target returns to idling after having been distracted
+	local aiplayer = include("sim/aiplayer")
+	local returnToIdleSituation_old = aiplayer.returnToIdleSituation
+
+	function aiplayer.returnToIdleSituation( self, unit )
+		returnToIdleSituation_old( self, unit )
+		if unit:getTraits().MM_bounty_target_spotted == true then
+			unit:createTab( STRINGS.MISSIONS.UTIL.HEAT_SIGNATURE_DETECTED, "" )
+		end
+	end
+
+	local simunit = include("sim/simunit")
+	local destroyTab_old = simunit.destroyTab
+
+	function simunit.destroyTab( self, unlessThisTab )
+		if self._tab = { , } then
+
+
 	--cannot set display string... local variable only -M
 	table.insert(modApi.mod_manager.credit_sources, "assassinationreward")
   

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -102,13 +102,6 @@ local function init( modApi )
 		end
 	end
 
-	local simunit = include("sim/simunit")
-	local destroyTab_old = simunit.destroyTab
-
-	function simunit.destroyTab( self, unlessThisTab )
-		if self._tab = { , } then
-
-
 	--cannot set display string... local variable only -M
 	table.insert(modApi.mod_manager.credit_sources, "assassinationreward")
   


### PR DESCRIPTION
Covers a variety of situations to make the "Heat Signature Detected" label in the Assassination mission smoother. Still not perfect, but should be close enough to the base game.