### PR TITLE
Don't crash on player loss

### DIFF
--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -205,7 +205,7 @@ local function lateInit( modApi )
 		--update existing informant bonuses
 		-- bonus doesn't apply in Omni missions so don't tick down
 		-- don't use up bonus if PC lost > might still Retry level
-		if sim:getPlayers()[sim:getWinner()]:isPC() and (not ((sim:getParams().world == "omni") or (sim:getParams().world == "omni2"))) then
+		if sim:getWinner() and sim:getPlayers()[sim:getWinner()]:isPC() and (not ((sim:getParams().world == "omni") or (sim:getParams().world == "omni2"))) then
 			agency.MM_informant_bonus = agency.MM_informant_bonus or {}
 			-- tick duration on existing mole bonuses
 			for i=#agency.MM_informant_bonus, 1, -1 do --do not modify agency during serialisation, doFinishMission is fine because no more serialisable player actions are possible


### PR DESCRIPTION
Loss is marked by `sim:getWinner() == nil`, not having it point at the NPC player.