### PR TITLE
Courier Reward: Fix distance failover, and add a followup corp failover

### DIFF
--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -1035,10 +1035,20 @@ local function load( modApi, options, params )
 	serverdefs.createNewSituation = function( campaign, gen, tags, difficulty )
 		local newSituation =  serverdefs_createNewSituation_old(campaign, gen, tags, difficulty )
 
-		if not newSituation and array.find(tags, "close_by") and not array.find(tags, "close_by_nevermind") then
+		if not newSituation and array.find(tags, "close_by") then
 			-- Secure Holding Facility/Courier Rescue: if there was no viable location, lift the requirement for proximity.
-			table.insert(tags, "close_by_nevermind")
-			newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
+			if not array.find(tags, "close_by_nevermind") then
+				table.insert(tags, "close_by_nevermind")
+				newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
+			end
+			if not newSituation and not array.find(tags, "corp_nevermind") then
+				-- Still no viable location. Allow any corp.
+				-- (Presence of corp in the tags list is sufficient, no need to remove any existing corp tag)
+				table.insert(tags, "corp_nevermind")
+				array.concat(tags, serverdefs.CORP_NAMES)
+				newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
+			end
+			-- If there's still no new situation, then there are no valid spawns (possibly from 2x of all mission types in endless). Give up.
 		end
 
 		if newSituation then


### PR DESCRIPTION
Fixes #86 

> If there weren't any nearby locations, the `if newSituation` condition wasn't met, so the failover code wasn't running. Moved the failover out of that block, and have it reattempt the old createNewSituation with the widened parameters.

> If there are no valid spawns within the current corp, still attempt to give 3 missions, from any corp at this point.
>
> The same tags array is used in all 3 generated locations, so each of the failover checks (and an extra call to the underlying createNewSituation) will occur at most once per reward screen.

Also tested that this correctly grants no new missions if there's already 2 of each mission on the map (disabled distress call in campaign options for this, because it auto-clears). As expected, the extra failover checks only resulted in 2 extra calls to the underlying code.