### PR TITLE
Assassination fixes

### DIFF
--- a/scripts/appended_functions/engine_lateInit.lua
+++ b/scripts/appended_functions/engine_lateInit.lua
@@ -8,6 +8,8 @@ local abilityutil = include( "sim/abilities/abilityutil" )
 local cdefs = include( "client_defs" )
 local simdefs = include( "sim/simdefs" )
 
+local assassination_mission = include( SCRIPT_PATHS.more_missions .. "/missions/assassination" )
+
 local simengine = include("sim/engine")
 local simengine_tryShootAt_old = simengine.tryShootAt
 simengine.tryShootAt = function( self, sourceUnit, targetUnit, dmgt, equipped, ... )

--- a/scripts/appended_functions/units_lateInit.lua
+++ b/scripts/appended_functions/units_lateInit.lua
@@ -8,6 +8,8 @@ local abilityutil = include( "sim/abilities/abilityutil" )
 local cdefs = include( "client_defs" )
 local simdefs = include( "sim/simdefs" )
 
+local assassination_mission = include( SCRIPT_PATHS.more_missions .. "/missions/assassination" )
+
 -- SIMUNIT ------------------------------------------------
 -- setAlerted edit to allow un-alerting for Amnesiac function
 local simunit = include("sim/simunit")

--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -28,6 +28,14 @@ end
 
 ----
 -- Trigger Definitions
+
+-- Like mission_util.PC_ANY, but after the action completes instead of before.
+-- Allows triggering before returning to player control.
+local PC_AFTER_ANY =
+{
+	action = "", -- Any action
+}
+
 --interest triggers so bodyguard can investigate instead VIP
 local DECOY_REVEALED = 
 {
@@ -777,7 +785,7 @@ local function despawnDecoy( script, sim )
 	end
 	
 	script:queue( { type="hideHUDInstruction" } ) 
-	script:waitFor( mission_util.PC_ANY )
+	script:waitFor( mission_util.PC_ANY, PC_AFTER_ANY )
 	sim:warpUnit( decoyUnit, nil ) -- remove the original
 	sim:despawnUnit( decoyUnit ) 
 	


### PR DESCRIPTION
* 2 undefined references to `assassination_mission` in appends
* Add an additional trigger for despawning the "hologram" unit.
  * Previously, there was a brief window where it looked like the player could steal from both the hologram and the revealed decoy. Now the decoy despawns before returning to player control.