### PR TITLE
Rebalance non-agent Distress Call loot table

### DIFF
--- a/scripts/appended_functions/serverdefs.lua
+++ b/scripts/appended_functions/serverdefs.lua
@@ -27,6 +27,7 @@ local function earlyLoad()
 		"item_cloakingrig_1",     -- 1, 400
 		"item_lockdecoder",       -- 1, 400
 		"item_icebreaker_2",      -- 2, 400
+		"item_emp_pack",          -- 1, 500
 		"item_paralyzer_2",       -- 2, 500
 		"item_portabledrive_2",   -- 2, 500
 		"item_hologrenade_17_9",  -- 2, 600

--- a/scripts/appended_functions/serverdefs.lua
+++ b/scripts/appended_functions/serverdefs.lua
@@ -8,9 +8,49 @@ local abilityutil = include( "sim/abilities/abilityutil" )
 local cdefs = include( "client_defs" )
 local simdefs = include( "sim/simdefs" )
 
-local function runAppend()
--- default weight for missions with no weight is 1, but the function doesn't accept weight less than 1. Set it to 100 instead so we can make missions both less frequent and more frequent than the vanilla unweighted ones without overriding the rest of the function.
+-- === earlyLoad ===
+local function earlyLoad()
 
+	-- If Distress Call doesn't contain an agent, the loot is a vault passcard and one of these, instead.
+	-- * 300-600cr, other than the non-purchaseable prototype drive
+	-- * mean=420
+	local MM_DISTRESS_CALL_ITEMS_DEFAULT = {
+		                          -- (floor weight, purchase value)
+		"item_light_pistol",      -- 0, 300
+		"item_crybaby",           -- 2, 300
+		"item_stickycam",         -- 2, 300
+		"item_smokegrenade",      -- 2, 300
+		"item_tag_pistol",        -- 0, 300 (higher perceived value)
+		"MM_item_corpIntel",      -- reward = 300*scaling
+		"item_shocktrap",         -- 1, 400
+		"item_stim",              -- 1, 400
+		"item_cloakingrig_1",     -- 1, 400
+		"item_lockdecoder",       -- 1, 400
+		"item_icebreaker_2",      -- 2, 400
+		"item_paralyzer_2",       -- 2, 500
+		"item_portabledrive_2",   -- 2, 500
+		"item_hologrenade_17_9",  -- 2, 600
+		"item_wireless_scanner_1",-- 3, 600 (not purchaseable)
+		"item_prototype_drive",   -- 3, 700 (not purchaseable)
+	}
+
+	serverdefs.MM_DISTRESS_CALL_ITEMS = {}
+
+	local function ResetMMDistressCallItems()
+		log:write("ResetMMDistressCallItems()")
+		util.tclear(serverdefs.MM_DISTRESS_CALL_ITEMS)
+		util.tmerge(serverdefs.MM_DISTRESS_CALL_ITEMS, MM_DISTRESS_CALL_ITEMS_DEFAULT)
+	end
+
+	ResetMMDistressCallItems()
+end
+-- === END earlyLoad ===
+
+
+-- === lateLoad ===
+local function lateLoad()
+
+-- default weight for missions with no weight is 1, but the function doesn't accept weight less than 1. Set it to 100 instead so we can make missions both less frequent and more frequent than the vanilla unweighted ones without overriding the rest of the function.
 local serverdefs_chooseSituation_old = serverdefs.chooseSituation
 serverdefs.chooseSituation = function( campaign, tags, gen, ... )
 	for name, situationData in pairs( serverdefs.SITUATIONS ) do
@@ -72,5 +112,9 @@ serverdefs.defaultMapSelector = function( campaign, tags, tempLocation )
 end
 
 end
+-- === END lateLoad ===
 
-return { runAppend = runAppend }
+return {
+	earlyLoad = earlyLoad,
+	lateLoad = lateLoad,
+}

--- a/scripts/appended_functions/serverdefs.lua
+++ b/scripts/appended_functions/serverdefs.lua
@@ -49,7 +49,7 @@ end
 
 
 -- === lateLoad ===
-local function lateLoad()
+local function lateLoad( mod_options )
 
 -- default weight for missions with no weight is 1, but the function doesn't accept weight less than 1. Set it to 100 instead so we can make missions both less frequent and more frequent than the vanilla unweighted ones without overriding the rest of the function.
 local serverdefs_chooseSituation_old = serverdefs.chooseSituation
@@ -94,6 +94,19 @@ serverdefs.createNewSituation = function( campaign, gen, tags, difficulty )
 	end
 
 	return newSituation
+end
+
+--DISTRESS CALL
+-- Check for item mods that add items in the right value range for non-agent Distress Call loot.
+local niaa = mod_manager.findModByName and mod_manager:findModByName( "New Items And Augments" )
+if niaa and mod_options[niaa.id] and mod_options[niaa.id].enabled then
+	local niaaOptions = mod_options[niaa.id].options
+	if niaaOptions["enable_items"] and niaaOptions["enable_items"].enabled then
+		table.insert(serverdefs.MM_DISTRESS_CALL_ITEMS, "W93_item_door_controller") -- 2, 400
+	end
+	if niaaOptions["enable_weapons"] and niaaOptions["enable_weapons"].enabled then
+		table.insert(serverdefs.MM_DISTRESS_CALL_ITEMS, "W93_weapon_emp_pistol") -- 0, 450
+	end
 end
 
 --SECURE HOLDING FACILITY/COURIER RESCUE

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -121,9 +121,9 @@ local function make_gear( sim, newUnit, agentTemplate )
 	-- * mostly tier-2 or 500-800cr, no single-use items
 	-- * mean=640
 	local template_list = {   -- (floor weight, purchase value)
-	"item_corpIntel",         -- reward = 300*scaling (similar to selling a 600cr item, but worse than using one)
 	"item_tag_pistol",        -- 0, 300 (higher perceived value)
 	"item_icebreaker_2",      -- 2, 400
+	"MM_item_corpIntel",      -- reward = 500*scaling
 	"item_paralyzer_2",       -- 2, 500
 	"item_portabledrive_2",   -- 2, 500
 	"item_hologrenade_17_9",  -- 2, 600

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -111,34 +111,36 @@ end
 
 local function make_gear( sim, newUnit, agentTemplate )
 
-	-- Distress Call: 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
-	-- Security Dispatch: 150*scaling ("safe") + item of floor weight 3+
-	--  * item value (vanilla+DLC): mean=1030, min=600, max=1500
-	-- CFO: 450*scaling (CFO) + vault_passcard
-	-- (scaling @E/E+ = 0.75-1.3  @E++ = 0.5-0.875)
+	-- Comparable vanilla rewards: (scaling @E/E+ = 0.75-1.3  @E++ = 0.5-0.875)
+	-- * Detention Centre (prisoner): 800*scaling (reward)
+	-- * Security Dispatch: 150*scaling ("safe") + item of floor weight 3+
+	--   * item value (vanilla+DLC): mean=1030, min=600, max=1500
+	-- * CFO: 450*scaling (CFO) + vault_passcard
+	--
+	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
+	-- * mostly tier-2 or 500-800cr, no single-use items
+	-- * mean=640
 	local template_list = {   -- (floor weight, purchase value)
-	"item_adrenaline",        -- 0, 275 (low player value)
-	"item_light_pistol",      -- 0, 300
-	"item_crybaby",           -- 2, 300
-	"item_stickycam",         -- 2, 300
-	"item_smokegrenade",      -- 2, 300
-	"item_tag_pistol",        -- 0, 300 (high player value)
-	"item_clip",              -- 0, 400 (low player value)
-	"item_cloakingrig_1",     -- 1, 400
-	"item_lockdecoder",       -- 1, 400
+	"item_corpIntel",         -- reward = 300*scaling (similar to selling a 600cr item, but worse than using one)
+	"item_tag_pistol",        -- 0, 300 (higher perceived value)
 	"item_icebreaker_2",      -- 2, 400
 	"item_paralyzer_2",       -- 2, 500
 	"item_portabledrive_2",   -- 2, 500
-	"item_corpIntel",         -- reward = 300*scaling (better than selling a 600cr item, but worse than using one)
 	"item_hologrenade_17_9",  -- 2, 600
-	"item_flashgrenade",      -- 2, 600
 	"item_wireless_scanner_1",-- 3, 600 (not purchaseable)
+	"item_cloakingrig_2",     -- 2, 700
 	"item_shocktrap_2",       -- 2, 700
 	"item_prototype_drive",   -- 3, 700 (not purchaseable)
 	"item_econchip",          -- 1, 800
 	"item_stim_2",            -- 2, 800
 	"item_flash_pack",        -- 2, 900
 	"item_laptop_2",          -- 2, 1000
+
+	-- NIAA might make these more reasonable as rewards
+	-- "item_crybaby",           -- 2, 300  ->  2, 300
+	-- "item_stickycam",         -- 2, 300  ->  2, 400
+	-- "item_smokegrenade",      -- 2, 300  ->  2, 300
+	-- "item_lockdecoder",       -- 1, 400  ->  2, 450 (though odd paired with a vault card)
 	}
 	local new_items = {}
 	local captured_items = {} --separate table for these as they're already spawned

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -117,30 +117,26 @@ local function make_gear( sim, newUnit, agentTemplate )
 	--   * item value (vanilla+DLC): mean=1030, min=600, max=1500
 	-- * CFO: 450*scaling (CFO) + vault_passcard
 	--
-	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
-	-- * mostly tier-2 or 500-800cr, no single-use items
-	-- * mean=640
+	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard (500) + 1 of these
+	-- * 300-600cr, other than the non-purchaseable prototype drive
+	-- * mean=420
 	local template_list = {   -- (floor weight, purchase value)
+	"item_light_pistol",      -- 0, 300
+	"item_crybaby",           -- 2, 300
+	"item_stickycam",         -- 2, 300
+	"item_smokegrenade",      -- 2, 300
 	"item_tag_pistol",        -- 0, 300 (higher perceived value)
+	"MM_item_corpIntel",      -- reward = 300*scaling
+	"item_shocktrap",         -- 1, 400
+	"item_stim",              -- 1, 400
+	"item_cloakingrig_1",     -- 1, 400
+	"item_lockdecoder",       -- 1, 400
 	"item_icebreaker_2",      -- 2, 400
-	"MM_item_corpIntel",      -- reward = 500*scaling
 	"item_paralyzer_2",       -- 2, 500
 	"item_portabledrive_2",   -- 2, 500
 	"item_hologrenade_17_9",  -- 2, 600
 	"item_wireless_scanner_1",-- 3, 600 (not purchaseable)
-	"item_cloakingrig_2",     -- 2, 700
-	"item_shocktrap_2",       -- 2, 700
 	"item_prototype_drive",   -- 3, 700 (not purchaseable)
-	"item_econchip",          -- 1, 800
-	"item_stim_2",            -- 2, 800
-	"item_flash_pack",        -- 2, 900
-	"item_laptop_2",          -- 2, 1000
-
-	-- NIAA might make these more reasonable as rewards
-	-- "item_crybaby",           -- 2, 300  ->  2, 300
-	-- "item_stickycam",         -- 2, 300  ->  2, 400
-	-- "item_smokegrenade",      -- 2, 300  ->  2, 300
-	-- "item_lockdecoder",       -- 1, 400  ->  2, 450 (though odd paired with a vault card)
 	}
 	local new_items = {}
 	local captured_items = {} --separate table for these as they're already spawned

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -1,5 +1,6 @@
 local array = include( "modules/array" )
 local util = include( "modules/util" )
+local serverdefs = include( "modules/serverdefs" )
 local cdefs = include( "client_defs" )
 local simdefs = include( "sim/simdefs" )
 local simquery = include( "sim/simquery" )
@@ -120,24 +121,7 @@ local function make_gear( sim, newUnit, agentTemplate )
 	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard (500) + 1 of these
 	-- * 300-600cr, other than the non-purchaseable prototype drive
 	-- * mean=420
-	local template_list = {   -- (floor weight, purchase value)
-	"item_light_pistol",      -- 0, 300
-	"item_crybaby",           -- 2, 300
-	"item_stickycam",         -- 2, 300
-	"item_smokegrenade",      -- 2, 300
-	"item_tag_pistol",        -- 0, 300 (higher perceived value)
-	"MM_item_corpIntel",      -- reward = 300*scaling
-	"item_shocktrap",         -- 1, 400
-	"item_stim",              -- 1, 400
-	"item_cloakingrig_1",     -- 1, 400
-	"item_lockdecoder",       -- 1, 400
-	"item_icebreaker_2",      -- 2, 400
-	"item_paralyzer_2",       -- 2, 500
-	"item_portabledrive_2",   -- 2, 500
-	"item_hologrenade_17_9",  -- 2, 600
-	"item_wireless_scanner_1",-- 3, 600 (not purchaseable)
-	"item_prototype_drive",   -- 3, 700 (not purchaseable)
-	}
+	local template_list = serverdefs.MM_DISTRESS_CALL_ITEMS
 	local new_items = {}
 	local captured_items = {} --separate table for these as they're already spawned
 	if newUnit:getUnitData().agentID then

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -117,7 +117,7 @@ local function make_gear( sim, newUnit, agentTemplate )
 	--   * item value (vanilla+DLC): mean=1030, min=600, max=1500
 	-- * CFO: 450*scaling (CFO) + vault_passcard
 	--
-	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
+	-- Distress Call (Lien): 600*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
 	-- * mostly tier-2 or 500-800cr, no single-use items
 	-- * mean=640
 	local template_list = {   -- (floor weight, purchase value)
@@ -456,7 +456,7 @@ local function got_operative(script, sim, mission)
 		sim.TA_mission_success = true -- flag for Talkative Agents
 	else
 		mission.operative_extracted = true
-		sim:setMissionReward( simquery.scaleCredits( sim, 800 )) --keep this money reward unless we can think of something more exciting/original
+		sim:setMissionReward( simquery.scaleCredits( sim, 600 )) --keep this money reward unless we can think of something more exciting/original
 		sim.TA_mission_success = true
 	end
 	sim:removeObjective( "rescue_agent" )

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -117,7 +117,7 @@ local function make_gear( sim, newUnit, agentTemplate )
 	--   * item value (vanilla+DLC): mean=1030, min=600, max=1500
 	-- * CFO: 450*scaling (CFO) + vault_passcard
 	--
-	-- Distress Call (Lien): 600*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
+	-- Distress Call (Lien): 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
 	-- * mostly tier-2 or 500-800cr, no single-use items
 	-- * mean=640
 	local template_list = {   -- (floor weight, purchase value)
@@ -456,7 +456,7 @@ local function got_operative(script, sim, mission)
 		sim.TA_mission_success = true -- flag for Talkative Agents
 	else
 		mission.operative_extracted = true
-		sim:setMissionReward( simquery.scaleCredits( sim, 600 )) --keep this money reward unless we can think of something more exciting/original
+		sim:setMissionReward( simquery.scaleCredits( sim, 800 )) --keep this money reward unless we can think of something more exciting/original
 		sim.TA_mission_success = true
 	end
 	sim:removeObjective( "rescue_agent" )

--- a/scripts/missions/distress_call.lua
+++ b/scripts/missions/distress_call.lua
@@ -111,30 +111,34 @@ end
 
 local function make_gear( sim, newUnit, agentTemplate )
 
-	local template_list = {
-	-- "vault_passcard",
-	"item_corpIntel",
-	"item_crybaby",
-	"item_flash_pack",
-	"item_clip",
-	"item_tag_pistol",
-	"item_flashgrenade",
-	"item_stickycam",
-	"item_hologrenade_17_9",
-	"item_smokegrenade",
-	"item_adrenaline",
-	"item_stim_2",
-	"item_paralyzer_2",
-	"item_laptop_2",
-	"item_cloakingrig_1",
-	"item_icebreaker_2",
-	"item_prototype_drive",
-	"item_portabledrive_2",
-	"item_econchip",
-	"item_lockdecoder",
-	"item_shocktrap_2",
-	"item_wireless_scanner_1",
-	"item_light_pistol",
+	-- Distress Call: 800*scaling (reward) + 80*scaling (guard) + vault_passcard + 1 of these
+	-- Security Dispatch: 150*scaling ("safe") + item of floor weight 3+
+	--  * item value (vanilla+DLC): mean=1030, min=600, max=1500
+	-- CFO: 450*scaling (CFO) + vault_passcard
+	-- (scaling @E/E+ = 0.75-1.3  @E++ = 0.5-0.875)
+	local template_list = {   -- (floor weight, purchase value)
+	"item_adrenaline",        -- 0, 275 (low player value)
+	"item_light_pistol",      -- 0, 300
+	"item_crybaby",           -- 2, 300
+	"item_stickycam",         -- 2, 300
+	"item_smokegrenade",      -- 2, 300
+	"item_tag_pistol",        -- 0, 300 (high player value)
+	"item_clip",              -- 0, 400 (low player value)
+	"item_cloakingrig_1",     -- 1, 400
+	"item_lockdecoder",       -- 1, 400
+	"item_icebreaker_2",      -- 2, 400
+	"item_paralyzer_2",       -- 2, 500
+	"item_portabledrive_2",   -- 2, 500
+	"item_corpIntel",         -- reward = 300*scaling (better than selling a 600cr item, but worse than using one)
+	"item_hologrenade_17_9",  -- 2, 600
+	"item_flashgrenade",      -- 2, 600
+	"item_wireless_scanner_1",-- 3, 600 (not purchaseable)
+	"item_shocktrap_2",       -- 2, 700
+	"item_prototype_drive",   -- 3, 700 (not purchaseable)
+	"item_econchip",          -- 1, 800
+	"item_stim_2",            -- 2, 800
+	"item_flash_pack",        -- 2, 900
+	"item_laptop_2",          -- 2, 1000
 	}
 	local new_items = {}
 	local captured_items = {} --separate table for these as they're already spawned

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -423,7 +423,7 @@ local function load( modApi, options, params )
 	
 end
 
-local function lateLoad( modApi, options, params )
+local function lateLoad( modApi, options, params, mod_options )
 	local scriptPath = modApi:getScriptPath()
 	local tech_expo_itemdefs = include( scriptPath .. "/tech_expo_itemdefs" )
 	for name, itemDef in pairs(tech_expo_itemdefs.generateTechExpoGear()) do
@@ -440,7 +440,7 @@ local function lateLoad( modApi, options, params )
 	--ASSASSINATION, COURIER RESCUE
 	-- SimConstructor resets serverdefs with every load, hence this function wrap only applies once despite being in mod-load. If SimConstructor ever changes, this must too.
 	local serverdefs_appends = include( scriptPath .. "/appended_functions/serverdefs" )
-	serverdefs_appends.lateLoad()
+	serverdefs_appends.lateLoad( mod_options )
 end
 
 local function unload( modApi, options )

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -181,6 +181,13 @@ local function unloadCommon( modApi, options )
 
 end
 
+local function earlyLoad( modApi, options, params )
+    local scriptPath = modApi:getScriptPath()
+
+	local serverdefs_appends = include( scriptPath .. "/appended_functions/serverdefs" )
+	serverdefs_appends.earlyLoad()
+end
+
 local function load( modApi, options, params )
 	--before doing anything, clean up
 	unloadCommon( modApi, options )
@@ -430,10 +437,10 @@ local function lateLoad( modApi, options, params )
 	----- Distress Call mission hackz - Hek. They need to be in Load too. make that lateLoad because of Additional Banter
 	include( scriptPath .. "/appended_functions/mission_util_lateLoad" )	
 	
-	--ASSASSINATION
+	--ASSASSINATION, COURIER RESCUE
 	-- SimConstructor resets serverdefs with every load, hence this function wrap only applies once despite being in mod-load. If SimConstructor ever changes, this must too.
-	local serverdef_appends = include( scriptPath .. "/appended_functions/serverdefs" )
-	serverdef_appends.runAppend()	
+	local serverdefs_appends = include( scriptPath .. "/appended_functions/serverdefs" )
+	serverdefs_appends.lateLoad()
 end
 
 local function unload( modApi, options )
@@ -457,6 +464,7 @@ return {
     init = init,
     earlyInit = earlyInit,
     lateInit = lateInit,
+    earlyLoad = earlyLoad,
     load = load,
     lateLoad = lateLoad,
     unload = unload,

--- a/scripts/propdefs.lua
+++ b/scripts/propdefs.lua
@@ -467,8 +467,9 @@ local prop_templates =
 		icon = "itemrigs/FloorProp_DataDisc.png",
 		profile_icon = "gui/icons/item_icons/items_icon_small/icon-item_data_disk_small.png",
 		profile_icon_100 = "gui/icons/item_icons/icon-item_data_disk.png",
-		-- Buffed to 500cr, from 300 on the unused vanilla item
-		traits = { selectpriority = 0, cashInReward = 500, showOnce = "corp_intel" },
+		-- Remove a number of irrelevant traits from the vanilla item_corpIntel
+		-- Also, just in case we want to tweak the value. (vanilla = 300cr)
+		traits = { selectpriority = 0, cashInReward = 300, showOnce = "corp_intel" },
 		abilities = { "carryable" },
 	},
 

--- a/scripts/propdefs.lua
+++ b/scripts/propdefs.lua
@@ -456,6 +456,22 @@ local prop_templates =
 		}
     },		
 
+	-- Distress Call
+	MM_item_corpIntel =
+	{
+		type = "simunit",
+		name =  STRINGS.PROPS.CORP_INTEL,
+        onWorldTooltip = commondefs.onItemWorldTooltip,
+        onTooltip = commondefs.onItemTooltip,
+		desc = STRINGS.PROPS.CORP_INTEL_DESC,
+		icon = "itemrigs/FloorProp_DataDisc.png",
+		profile_icon = "gui/icons/item_icons/items_icon_small/icon-item_data_disk_small.png",
+		profile_icon_100 = "gui/icons/item_icons/icon-item_data_disk.png",
+		-- Buffed to 500cr, from 300 on the unused vanilla item
+		traits = { selectpriority = 0, cashInReward = 500, showOnce = "corp_intel" },
+		abilities = { "carryable" },
+	},
+
 	--------------- SIDE MISSIONS ---------------------
 	MM_W93_crate = --24 BRIEFCASES
 	{


### PR DESCRIPTION
Previous mean value: 520
Updated mean value: 640
Range is still 300-1000

* Removed single-use items and items <500cr (except TAG pistol and buster chip II, which are usually perceived as higher value)
* Upgrade cloak I to cloak II (other items are Tier II)
* Upgrade Corporate Intel (valuable loot) from 300cr to 500cr. It's too thematic to cut, so I buffed its value.

`800* + 80* + 500 + ~640 = 2020` is just shy of Assassination's current `1500* + 200* + 150* + 300 = 2150` and comparable to a full vault. Unclear whether or not this is reasonable.
If you get a high-roll item that you want to use _and_ make use of the vault card, this is easily the most valuable mission reward.