### PR TITLE
Use a callback pattern for generic "update agency" mission rewards

### DIFF
--- a/scripts/appended_functions/mission_scoring.lua
+++ b/scripts/appended_functions/mission_scoring.lua
@@ -103,14 +103,21 @@ local function runAppend( modApi )
 			sim._resultTable.credits_gained.assassinationreward = sim._assassinationReward
 		end
 		
-		-- NEW: this moves every PC_WON block from mission scripts to here
-		if sim.TEMP_AGENCY then
-			-- Accessing the agency from the sim (even during DoFinishMission) doesn't help, that's what's the cause of all this: The campaign that's in the sim and in the savefile are different. You need to get it from the savefile.  -- Cyberboy2000
+		-- For a mission to arbitrarily update the agency,
+		-- 1. Define a function that takes (sim,agency) parameters, updating the agency based on values on the sim.
+		-- 2. Add that function to the list of callback functions to be applied when the mission is over:
+		-- ```
+		--   sim.MM_agencyUpdates = sim.MM_agencyUpdates or {}
+		--   table.insert( sim.MM_agencyUpdates, updateAgency )
+		-- ```
+		if sim.MM_agencyUpdates then
+			-- Accessing the agency from the sim (even during DoFinishMission) doesn't help, that's what's the cause of all this: The campaign that's in the sim and in the savefile are different. You need to get it from the savefile. Getting agency from campaign is also fine. -- Cyberboy2000
 			-- local user = savefiles.getCurrentGame()
 			-- local campaign = user.data.saveSlots[ user.data.currentSaveSlot ]
-			-- util.tmerge(campaign.agency, sim.TEMP_AGENCY)
 
-			util.tmerge(campaign.agency, sim.TEMP_AGENCY) --getting agency from campaign is also fine
+			for _, updateCallback in ipairs(sim.MM_agencyUpdates) do
+				updateCallback(sim, campaign.agency)
+			end
 		end
 		
 		log:write("LOG MM agency")

--- a/scripts/escape_mission.lua
+++ b/scripts/escape_mission.lua
@@ -88,21 +88,24 @@ local function updateRefitDrone( script, sim )
 	drone:getTraits().MM_refitDroneRescue = true
 end
 
-local function waitForDroneEscape( script, sim )
-	local _, drone = script:waitFor( REFIT_DRONE_ESCAPED )
-	local name = drone:getTraits().customName
+-- Callback to be applied in mission_scoring
+local function updateAgencyForRefitDrone( sim, agency )
+	local name = sim:getTags().MM_rescuedRefitDroneName
 	local campaignHours = sim:getParams().campaignHours
-	
-	-- script:waitFor( PC_WON )
-	sim.TEMP_AGENCY = sim.TEMP_AGENCY or {}
-	-- local agency = sim:getParams().agency --we move this to DoFinishMission instead
-	local agency = sim.TEMP_AGENCY
-	agency.MM_rescuedRefitDrone = agency.MM_rescuedRefitDrone or {}
 
 	local droneData = {name = name, campaignHours = campaignHours}
 
-	agency.MM_rescuedRefitDrone[1] = droneData
+	agency.MM_rescuedRefitDrone = agency.MM_rescuedRefitDrone or {}
+	table.insert( agency.MM_rescuedRefitDrone, droneData )
+end
 
+local function waitForDroneEscape( script, sim )
+	local _, drone = script:waitFor( REFIT_DRONE_ESCAPED )
+	sim:getTags().MM_rescuedRefitDroneName = drone:getTraits().customName
+
+	-- Updates will be applied in mission_scoring
+	sim.MM_agencyUpdates = sim.MM_agencyUpdates or {}
+	table.insert( sim.MM_agencyUpdates, updateAgencyForRefitDrone )
 end
 
 local function droneSpeech( script, sim )

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -276,6 +276,11 @@ local function load( modApi, options, params )
 		modApi:addSideMissions(scriptPath, { "MM_luxuryNanofab" } )
 		-- for vanilla side missions
 		include( scriptPath .. "/appended_functions/abilities/transformer_terminal")
+
+		-- (easy debugging of sidemissions: uncomment to clear the list and add just the sidemission to be tested)
+		--local worldgen = include( "sim/worldgen" )
+		--util.tclear(worldgen.SIDEMISSIONS)
+		--modApi:addSideMissions(scriptPath, { "???" } )
 	end
 
 	-- add all the custom NEW abilities (not appends to existing ones)


### PR DESCRIPTION
Replaces the handling used for AI Terminal and Drone Rescue side mission (looks like a bigger change than it is, because I needed to reorder things to define the `updateAgency` callback function before the script hook that uses it)