### PR TITLE
Use custom store types for Luxury Nanofab instead of the vanilla mission's "large" value

### DIFF
--- a/scripts/appended_functions/simstore_load.lua
+++ b/scripts/appended_functions/simstore_load.lua
@@ -1,0 +1,26 @@
+
+local function addMoreMissionsStores()
+	local simstore = include( "sim/units/store" )
+
+	local storeTypes = simstore.STORE_ITEM.storeType
+	simstore.STORE_ITEM.storeType.MM_luxuryItem = {
+		itemAmount = 16,
+		progAmount = 0,
+		weaponAmount = 0,
+		augmentAmount = 0,
+	}
+	simstore.STORE_ITEM.storeType.MM_luxuryWpn = {
+		itemAmount = 0,
+		progAmount = 0,
+		weaponAmount = 16,
+		augmentAmount = 0,
+	}
+	simstore.STORE_ITEM.storeType.MM_luxuryAug = {
+		itemAmount = 0,
+		progAmount = 0,
+		weaponAmount = 0,
+		augmentAmount = 16,
+	}
+end
+
+return { addMoreMissionsStores = addMoreMissionsStores }

--- a/scripts/escape_mission.lua
+++ b/scripts/escape_mission.lua
@@ -20,21 +20,21 @@ local DRONE_BANTER_CHANCE = 0.3
 
 --local helpers
 local 	PC_WON = --now unused
-	{		
-        priority = 10,
+	{
+		priority = 10,
 
-        trigger = simdefs.TRG_GAME_OVER,
-        fn = function( sim, evData )
-            if sim:getWinner() then
-                return sim:getPlayers()[sim:getWinner()]:isPC()
-            else
-                return false
-            end
-        end,
+		trigger = simdefs.TRG_GAME_OVER,
+		fn = function( sim, evData )
+			if sim:getWinner() then
+				return sim:getPlayers()[sim:getWinner()]:isPC()
+			else
+				return false
+			end
+		end,
 	}
-	
+
 --VANILLA REBALANCES
-local REFIT_DRONE_SPAWNED = 
+local REFIT_DRONE_SPAWNED =
 {
 	trigger = simdefs.TRG_UNIT_WARP,
 	fn = function( sim, triggerData )
@@ -67,7 +67,7 @@ local DRONE_BOOTED =
 local function doDroneBanter( script, sim, unit )
 	local drone_lines = STRINGS.MOREMISSIONS.AGENT_LINES.SIDE_MISSIONS.REFIT_DRONE
 	local drone_txt = drone_lines[sim:nextRand(1,#drone_lines)]
-	script:queue( { type="clearEnemyMessage" } )	
+	script:queue( { type="clearEnemyMessage" } )
 	script:queue( {
 		body=drone_txt,
 		header = unit:getName(),
@@ -76,7 +76,7 @@ local function doDroneBanter( script, sim, unit )
 		profileBuild = unit:getUnitData().profile_build or unit:getUnitData().profile_anim,
 		} )
 	script:queue( 5 * cdefs.SECONDS )
-	script:queue( { type="clearEnemyMessage" } )	
+	script:queue( { type="clearEnemyMessage" } )
 end
 
 local function updateRefitDrone( script, sim )
@@ -123,7 +123,7 @@ local function droneSpeech( script, sim )
 		elseif not drone:isKO() and drone:getPlayerOwner() and (drone:getPlayerOwner() == sim:getPC()) and (sim:nextRand() <= DRONE_BANTER_CHANCE) then
 			doDroneBanter( script, sim, drone )
 		end
-	end	
+	end
 end
 
 local function updatePWRTerminal( sim )
@@ -146,7 +146,7 @@ end
 ---------------------------------------------------------
 
 local safeUnit = nil
-	
+
 local function PC_SAW_UNIT_WITH_MARKER2( script, tag, marker )
 	return
 	{
@@ -161,7 +161,7 @@ local function PC_SAW_UNIT_WITH_MARKER2( script, tag, marker )
 				local x, y = evData.unit:getLocation()
 				safeUnit = evData.unit
 				script:queue( { type="displayHUDInstruction", text=marker, x=x, y=y } )
-				return true 
+				return true
 			else
 				return false
 			end
@@ -177,7 +177,7 @@ local function PC_LOOTED_STORAGE_SAFE()
 		fn = function( sim, triggerData )
 			if triggerData.targetUnit:hasTag("w93_storage_1") and not triggerData.targetUnit:getTraits().MM_W93_daemons_installed then
 				safeUnit = triggerData.targetUnit
-				return triggerData 
+				return triggerData
 			end
 		end,
 	}
@@ -283,36 +283,36 @@ end
 --- Personnel Hijack sideobjective
 local PC_KNOCKOUT_BOSS =
 {
-    trigger = simdefs.TRG_UNIT_KO,
-    fn = function( sim, triggerData )
+	trigger = simdefs.TRG_UNIT_KO,
+	fn = function( sim, triggerData )
 	if triggerData and (triggerData.ticks or 0) > 0 then
-		if (not sim:isVersion("0.17.12") and triggerData.unit:getTraits().ko_trigger == "intimidate_guard") or triggerData.unit:getTraits().bossUnit then 
-            		return triggerData.unit
-            	end
-        end
-    end
+		if (not sim:isVersion("0.17.12") and triggerData.unit:getTraits().ko_trigger == "intimidate_guard") or triggerData.unit:getTraits().bossUnit then
+					return triggerData.unit
+				end
+		end
+	end
 }
 
 local PC_KILL_BOSS =
 {
-    trigger = simdefs.TRG_UNIT_KILLED,
-    fn = function( sim, triggerData )
+	trigger = simdefs.TRG_UNIT_KILLED,
+	fn = function( sim, triggerData )
 	if triggerData then
-		if triggerData.unit:getTraits().bossUnit then 
-            		return triggerData.unit
-            	end
-        end
-    end
+		if triggerData.unit:getTraits().bossUnit then
+					return triggerData.unit
+				end
+		end
+	end
 }
 
-local BOSS_ESCAPED = 
+local BOSS_ESCAPED =
 {
-    trigger = "hostage_escaped",
-    fn = function( sim, triggerData )
-        if triggerData.unit:getTraits().bossUnit then
-            return triggerData.unit
-        end
-    end,     
+	trigger = "hostage_escaped",
+	fn = function( sim, triggerData )
+		if triggerData.unit:getTraits().bossUnit then
+			return triggerData.unit
+		end
+	end,
 }
 
 local function spottedBoss( script, sim )
@@ -394,16 +394,16 @@ end
 -------------------------------------------------------------------
 -- LUXURY  NANOFAB
 local BOUGHT_ITEM =
-{       
-    trigger = simdefs.TRG_BUY_ITEM,
-    fn = function( sim, triggerData )
-        if triggerData.shopUnit:getTraits().storeType and (triggerData.shopUnit:getTraits().storeType == "large") and triggerData.shopUnit:getTraits().luxuryNanofab and triggerData.shopUnit:hasAbility("showItemStore") then
-            return triggerData.shopUnit
-        end
-    end,
+{
+	trigger = simdefs.TRG_BUY_ITEM,
+	fn = function( sim, triggerData )
+		if triggerData.shopUnit:getTraits().storeType and (triggerData.shopUnit:getTraits().storeType == "large") and triggerData.shopUnit:getTraits().luxuryNanofab and triggerData.shopUnit:hasAbility("showItemStore") then
+			return triggerData.shopUnit
+		end
+	end,
 }
 
-local CLOSED_NANOFAB = 
+local CLOSED_NANOFAB =
 {
 	trigger = simdefs.TRG_CLOSE_NANOFAB,
 	fn = function( sim, triggerData )
@@ -420,28 +420,28 @@ local SUMMONED_GUARD =
 		if triggerData.unit and triggerData.consoleUnit then
 			return triggerData.unit and triggerData.consoleUnit
 		end
-	end	
+	end
 }
 
 local PC_LOOTED_ITEM_NANOFAB_KEY =
 {
-    trigger = "agentGotItem",
-    fn = function( sim, triggerData )
-        -- print("CHECK THE ITEM",triggerData.item:getName())
-        if triggerData.item:hasTrait("luxuryNanofabKey") then
-            return triggerData.item
-        end
-    end,
+	trigger = "agentGotItem",
+	fn = function( sim, triggerData )
+		-- print("CHECK THE ITEM",triggerData.item:getName())
+		if triggerData.item:hasTrait("luxuryNanofabKey") then
+			return triggerData.item
+		end
+	end,
 }
 
 local UNLOCKED_NANOFAB =
 {
-    trigger = "MM_unlockedLuxuryNanoab",
-    fn = function( sim, triggerData )
-        if triggerData.unit and triggerData.targetUnit then
-            return triggerData.unit and triggerData.targetUnit
-        end
-    end,
+	trigger = "MM_unlockedLuxuryNanoab",
+	fn = function( sim, triggerData )
+		if triggerData.unit and triggerData.targetUnit then
+			return triggerData.unit and triggerData.targetUnit
+		end
+	end,
 }
 
 local function findGuardWithKey( sim )
@@ -494,7 +494,7 @@ local function sawNanofab( script, sim )
 	local x0, y0 = nanofab:getLocation()
 	script:queue( { type="pan", x=x0, y=y0 } )
 	script:queue(1*cdefs.SECONDS)
-	
+
 	if sim:getTags().haveNanofabKey then
 		sim:removeObjective( "findLuxuryNanofab" )
 		sim:addObjective( STRINGS.MOREMISSIONS.MISSIONS.SIDEMISSIONS.LUXURY_NANOFAB.UNLOCK_NANOFAB, "unlockLuxuryNanofab" )
@@ -503,18 +503,18 @@ local function sawNanofab( script, sim )
 		sim:addObjective( STRINGS.MOREMISSIONS.MISSIONS.SIDEMISSIONS.LUXURY_NANOFAB.FIND_KEY, "findNanofabKey" )
 		script:queue( { script=SCRIPTS.INGAME.MM_SIDEMISSIONS.LUXURY_NANOFAB.SAW_NANOFAB, type="newOperatorMessage" } )
 	end
-	
+
 	script:waitFor( UNLOCKED_NANOFAB )
 	nanofab:destroyTab()
 	sim:removeObjective( "unlockLuxuryNanofab" )
 	script:queue(1*cdefs.SECONDS)
 	script:queue( { script=SCRIPTS.INGAME.MM_SIDEMISSIONS.LUXURY_NANOFAB.UNLOCKED_NANOFAB, type="newOperatorMessage" } )
-	
+
 	local _, shop = script:waitFor( BOUGHT_ITEM )
 	shop.items = {} -- this empties the nanofab stock and forces the shop dialogue to close
 	shop.weapons = {}
 	shop.augments = {}
-	
+
 	strings_screens.STR_346165218 = sim.old_augmenttip
 	strings_screens.STR_2618909495 = sim.old_weapontip
 	strings_screens.STR_590530336 = sim.old_itemtip
@@ -522,16 +522,16 @@ local function sawNanofab( script, sim )
 	shop:getTraits().mainframe_status = "off"
 	sim:dispatchEvent( simdefs.EV_PLAY_SOUND, "SpySociety/Actions/mainframe_object_off" )
 	sim:dispatchEvent( simdefs.EV_UNIT_REFRESH, { unit = shop } )
-	
+
 	script:queue(1*cdefs.SECONDS)
-	script:queue( { script=SCRIPTS.INGAME.MM_SIDEMISSIONS.LUXURY_NANOFAB.BOUGHT_ITEM, type="newOperatorMessage" } )	
-	
+	script:queue( { script=SCRIPTS.INGAME.MM_SIDEMISSIONS.LUXURY_NANOFAB.BOUGHT_ITEM, type="newOperatorMessage" } )
+
 end
 
 local function summonedGuard( script, sim )
 	local _, console = script:waitFor( SUMMONED_GUARD )
 	console:destroyTab()
-	
+
 	local guard = findGuardWithKey(sim)
 	script:queue( { type="clearOperatorMessage" } )
 	if guard then
@@ -539,7 +539,7 @@ local function summonedGuard( script, sim )
 		local interest = guard:getBrain():getSenses():addInterest( x1,  y1, simdefs.SENSE_HEARING, simdefs.REASON_ALARMEDSAFE, console)
 		interest.alwaysDraw = true
 		sim:processReactions()
-		
+
 		if not sim:getTags().haveNanofabKey then
 			script:queue(1*cdefs.SECONDS)
 			script:queue( { script=SCRIPTS.INGAME.MM_SIDEMISSIONS.LUXURY_NANOFAB.SUMMONED_GUARD, type="newOperatorMessage" } )
@@ -566,7 +566,7 @@ end
 
 local function closedFancyFab( script, sim)
 	local _, shop = script:waitFor(CLOSED_NANOFAB)
-	
+
 	strings_screens.STR_346165218 = sim.old_augmenttip
 	strings_screens.STR_2618909495 = sim.old_weapontip
 	strings_screens.STR_590530336 = sim.old_itemtip
@@ -574,15 +574,15 @@ local function closedFancyFab( script, sim)
 end
 
 local function populateFancyFab(sim)
-    local simstore = include( "sim/units/store" )
-    local computer = nil
-    for i, unit in pairs(sim:getAllUnits())do
-        if unit:getTraits().luxuryNanofab then
-            computer = unit
-        end
-    end   
+	local simstore = include( "sim/units/store" )
+	local computer = nil
+	for i, unit in pairs(sim:getAllUnits())do
+		if unit:getTraits().luxuryNanofab then
+			computer = unit
+		end
+	end
 
-    if computer then 
+	if computer then
 
 		--Use simstore.createStoreItems to generate a long list of item candidates for each category. This will contain duplicates
 		local possible_merch = {
@@ -590,18 +590,18 @@ local function populateFancyFab(sim)
 		[2] = {}, --augments
 		[3] = {}, --weapons
 		}
-		
+
 		for i = 40, 1, -1 do --40 iterations should be enough to get 16 unique items
 			local items, weapons, augments = simstore.createStoreItems( simstore.STORE_ITEM, computer, sim )
 			util.tmerge(possible_merch[1], items)
 			util.tmerge(possible_merch[2], augments)
 			util.tmerge(possible_merch[3], weapons)
 		end
-		
+
 		local itemType = sim:nextRand(1,3) --randomly choose either items, augments or weapons to populate the shop
 		sim.luxuryNanofabItemType = itemType
 		local merch_candidates = possible_merch[itemType]
-		
+
 		--remove_duplicates
 		local hash = {}
 		local unique_merch = {}
@@ -611,8 +611,8 @@ local function populateFancyFab(sim)
 			   table.insert(unique_merch,v)
 			   hash[v._unitData.id] = true
 		   end
-		end	
-		
+		end
+
 		-- distribute the possible merch randomly to fill up the three nanofab categories
 		local total_items = {
 			[1] = {},	--8 slots
@@ -620,23 +620,23 @@ local function populateFancyFab(sim)
 			[3] = {},	-- 4 slots
 		}
 		if #unique_merch > 0 then
-			
+
 			for i = #unique_merch, 1, -1 do -- will run until merch list potential is empty or all nanofab categories are full, whichever comes first
 				local item = sim:nextRand(1, #unique_merch)
 				local group_choice = sim:nextRand(1,#total_items) --pick one of three categories to populate
 				local item_group = total_items[group_choice]
 				local limit = 4 -- 4 slots
-				if group_choice == 1 then 
+				if group_choice == 1 then
 					limit = 8 --8 slots
 				end
-				if #item_group < limit then 
+				if #item_group < limit then
 					table.insert(item_group, unique_merch[i])
 					table.remove(unique_merch, i)
 				end
 			end
-			
+
 			computer.items, computer.weapons, computer.augments = total_items[1], total_items[2], total_items[3]
-			
+
 			computer:getTraits().mainframe_status = "off"
 			local itemTypeName
 			if itemType == 1 then
@@ -683,7 +683,7 @@ local function startWorkshopMission( script, sim )
 	sim.MM_workshop_pwr = 0
 	sim:addObjective( util.sformat( STRINGS.MOREMISSIONS.MISSIONS.SIDEMISSIONS.WORKSHOP.OBJECTIVE_1, sim.MM_workshop_pwr ), "reroute_workshop_pwr" )
 	sim:addObjective( STRINGS.MOREMISSIONS.MISSIONS.SIDEMISSIONS.WORKSHOP.OBJECTIVE_2, "use_workshop" )
-	
+
 	for _, simunit in pairs( sim:getAllUnits() ) do
 		if simunit:getTraits().mainframe_console then
 			simunit:giveAbility( "MM_workshop_reroute_pwr" )
@@ -757,17 +757,17 @@ end
 function init( scriptMgr, sim )
 	fixNoPatrolFacing( sim )
 	--sidemission stuff
-    local params = sim:getParams()
+	local params = sim:getParams()
 	if params.side_mission then
 		log:write("[MM] side mission")
 		log:write(util.stringize(params.side_mission,2))
 		-- CUSTOM MM SIDEMISSIONS
-        if params.side_mission == "MM_luxuryNanofab" then
+		if params.side_mission == "MM_luxuryNanofab" then
 			createKeyCarrier(sim)
 			populateFancyFab(sim)
 			scriptMgr:addHook( "sawNanofab", sawNanofab )
 			scriptMgr:addHook( "CLOSED_FANCYFAB", closedFancyFab, nil )
-			scriptMgr:addHook( "summonedGuard", summonedGuard ) 
+			scriptMgr:addHook( "summonedGuard", summonedGuard )
 			scriptMgr:addHook( "PC_lootedKey", PC_lootedKey )
 			scriptMgr:addHook( "sawConsole" , sawConsole )
 		elseif params.side_mission == "MM_w93_storageroom" then
@@ -816,7 +816,7 @@ function init( scriptMgr, sim )
 				updateCompileTerminal( sim )
 			end
 		end
-	end	
+	end
 end
 
 return {

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -261,6 +261,9 @@ local function load( modApi, options, params )
 		end
 	end
 
+	-- Additional store types for Luxury Nanofab
+	include(scriptPath .. "/appended_functions/simstore_load").addMoreMissionsStores()
+
 	local itemdefs = include( scriptPath .. "/itemdefs" )
 	for name, itemDef in pairs(itemdefs) do
 		modApi:addItemDef( name, itemDef )

--- a/scripts/propdefs.lua
+++ b/scripts/propdefs.lua
@@ -487,7 +487,15 @@ local prop_templates =
 		onWorldTooltip = onStoreTooltip,
 		kanim = "kanim_printer", 
 		rig ="corerig",
-		traits = util.extend( MAINFRAME_TRAITS ) { moveToDevice=true, cover = true, impass = {0,0}, storeType="large", sightable = true, largenano=true, luxuryNanofab = true,},
+		traits = util.extend( MAINFRAME_TRAITS ) {
+			moveToDevice=true,
+			cover = true,
+			impass = {0,0},
+			storeType = "large",
+			sightable = true,
+			largenano = true,
+			luxuryNanofab = true,
+		},
 		abilities = { "showItemStore" },
 		tags = {"MM_luxuryNanofab"},
 		sounds = {appeared="SpySociety/HUD/gameplay/peek_positive", }

--- a/scripts/propdefs.lua
+++ b/scripts/propdefs.lua
@@ -491,10 +491,12 @@ local prop_templates =
 			moveToDevice=true,
 			cover = true,
 			impass = {0,0},
-			storeType = "large",
+			storeType="MM_luxuryItem",  -- This will be replaced by the mission script.
+			noMandatoryItems = true,  -- No chargepack/medgel.
+			noDupes = true, -- No duplicate items. (Requires Function Library 1.100+)
 			sightable = true,
-			largenano = true,
-			luxuryNanofab = true,
+			-- largenano = true,  -- This flag is used by the vanilla Nanofab mission, inconsistently this or storeType in various checks.
+			luxuryNanofab = true,  -- Also replaced by the mission script.
 		},
 		abilities = { "showItemStore" },
 		tags = {"MM_luxuryNanofab"},

--- a/scripts/tech_expo_itemdefs.lua
+++ b/scripts/tech_expo_itemdefs.lua
@@ -89,8 +89,8 @@ function generateTechExpoGear()
 		itemdef.flavor = itemdef.flavor .. STRINGS.MOREMISSIONS.ITEMS.TECHEXPO_FLAVOR
 	end
 		
-	simlog("[MM] tech expo templates")
-	simlog(util.stringize(tech_expo_templates,3))
+	-- simlog("[MM] tech expo templates")
+	-- simlog(util.stringize(tech_expo_templates,3))
 
 	return tech_expo_templates
 end


### PR DESCRIPTION
Fixes #188

Using custom store types allows us to request a custom amount of given item types, so the mission script has been simplified. We don't need to generate multiple large-nanofabs-worth of items in order to fill the luxury nanofab.

!!! This change removes the code for enforcing no duplicate items in the resultant list. Instead, a `noDupes` flag is added to the traits, without any current implementation to use it.

I'm hoping wodzu will be willing to support a `noDupes` flag as part of `simstore.createStoreItems`, so that the luxury nanofab can be populated without the extra work to enforce no dupes _after_ generating a bunch of items. If not, then this should PR should be amended to put the remove-dupes logic back. (request: https://discord.com/channels/313015356052471828/589089660064628736/1185768998428737586)