### PR TITLE
Check playerOwner instead of firewalls for device canUse (rubiks bugfix)

### DIFF
--- a/scripts/abilities/MM_scrubcameradb.lua
+++ b/scripts/abilities/MM_scrubcameradb.lua
@@ -80,7 +80,7 @@ local MM_scrubcameradb = --tweaked version of monster root hub hack
 				-- return false, STRINGS.ABILITIES.HACK_ONLY_MOLE --only mole
 			-- end 
 
-			if abilityOwner:getTraits().mainframe_ice > 0 then 
+			if abilityOwner:getPlayerOwner() ~= sim:getPC() then
 				return false, STRINGS.ABILITIES.TOOLTIPS.UNLOCK_WITH_INCOGNITA
 			end
 			

--- a/scripts/abilities/MM_transformer_terminal_10PWR.lua
+++ b/scripts/abilities/MM_transformer_terminal_10PWR.lua
@@ -32,7 +32,7 @@ local MM_transformer_terminal_sell_PWR_10 =
                 return false
             end
 
-			if abilityOwner:getTraits().mainframe_ice > 0 then 
+			if abilityOwner:getPlayerOwner() ~= sim:getPC() then
 				return false, STRINGS.ABILITIES.TOOLTIPS.UNLOCK_WITH_INCOGNITA
 			end
 

--- a/scripts/abilities/MM_transformer_terminal_5PWR.lua
+++ b/scripts/abilities/MM_transformer_terminal_5PWR.lua
@@ -32,7 +32,7 @@ local MM_transformer_terminal_sell_PWR_5 =
                 return false
             end
 
-			if abilityOwner:getTraits().mainframe_ice > 0 then 
+			if abilityOwner:getPlayerOwner() ~= sim:getPC() then
 				return false, STRINGS.ABILITIES.TOOLTIPS.UNLOCK_WITH_INCOGNITA
 			end
 

--- a/scripts/abilities/MM_workshop_place_item.lua
+++ b/scripts/abilities/MM_workshop_place_item.lua
@@ -37,7 +37,7 @@ local MM_workshop_place_item =
 			return false
 		end
 
-		if unit:getTraits().mainframe_ice > 0 then
+		if unit:getPlayerOwner() ~= sim:getPC() then
 			return false, STRINGS.ABILITIES.TOOLTIPS.UNLOCK_WITH_INCOGNITA
 		end
 


### PR DESCRIPTION
Found when applying the rubiks bugfix to a bunch of DLC device abilities, and thought to check over here