### PR TITLE
Disallow diagonal drone interaction

### DIFF
--- a/scripts/abilities/MM_petDrone.lua
+++ b/scripts/abilities/MM_petDrone.lua
@@ -34,40 +34,6 @@ local MM_renameDrone =
 		profile_icon = "gui/icons/action_icons/Action_icon_Small/icon-item_hijack_small.png", -- NEEDS TO BE CUSTOM!!!!!!!!
 
 		-- Note that abilityOwner is the drone, unit is the agent!
-		acquireTargets = function( self, targets, game, sim, abilityOwner, unit )
-            if simquery.canUnitReach( sim, unit, abilityOwner:getLocation() ) and (unit ~= abilityOwner) then
-			    return targets.unitTarget( game, { abilityOwner }, self, abilityOwner, unit )
-            end
-		end,
-
-		-- Current acquireTargets allows diagonal petting, which crashes due to lack of diagonal animation.
-		-- Needs to be adapted to only allow orthogonal petting. Below example code taken from melee.acquireTargets.
-
-		-- acquireTargets = function( self, targets, game, sim, unit )
-			-- -- Check adjacent tiles
-			-- local targetUnits = {}
-			-- local cell = sim:getCell( unit:getLocation() )
-			-- --check for pinned guards
-			-- for i,cellUnit in ipairs(cell.units) do
-				-- if self:isValidTarget( sim, unit, unit, cellUnit ) then
-					-- table.insert( targetUnits,cellUnit )
-				-- end
-			-- end
-            -- for i = 1, #simdefs.OFFSET_NEIGHBOURS, 2 do
-    			-- local dx, dy = simdefs.OFFSET_NEIGHBOURS[i], simdefs.OFFSET_NEIGHBOURS[i+1]
-                -- local targetCell = sim:getCell( cell.x + dx, cell.y + dy )
-                -- if simquery.isConnected( sim, cell, targetCell ) then
-					-- for _,cellUnit in ipairs( targetCell.units ) do
-						-- if self:isValidTarget( sim, unit, unit, cellUnit ) then
-							-- table.insert( targetUnits,cellUnit )
-						-- end
-					-- end
-				-- end
-			-- end
-
-			-- return targets.unitTarget( game, targetUnits, self, unit, unit )
-		-- end,
-
 		canUseAbility = function( self, sim, abilityOwner, unit )
 			if abilityOwner == unit then
 				return false
@@ -77,7 +43,7 @@ local MM_renameDrone =
 				return false
 			end
 
-            return true
+            return simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
 		end,
 
 		executeAbility = function( self, sim, abilityOwner, unit )

--- a/scripts/abilities/MM_petDrone.lua
+++ b/scripts/abilities/MM_petDrone.lua
@@ -5,7 +5,7 @@ local simdefs = include("sim/simdefs")
 local simquery = include("sim/simquery")
 local abilityutil = include( "sim/abilities/abilityutil" )
 
-local MM_renameDrone = 
+local MM_renameDrone =
 	{
 		name = STRINGS.MOREMISSIONS.ABILITIES.RENAME_DRONE,
 
@@ -19,18 +19,18 @@ local MM_renameDrone =
 			end
 			if unit:getTraits().activate_txt_body then
 				body = unit:getTraits().activate_txt_body
-			end			
+			end
 
 			return abilityutil.formatToolTip( title,  body )
 		end,
-		
+
 		proxy = true,
 		ap_boost = 1,
 		HUDpriority = 2,
 		getName = function( self, sim, abilityOwner, abilityUser, targetUnitID )
 			return self.name
 		end,
-		
+
 		profile_icon = "gui/icons/action_icons/Action_icon_Small/icon-item_hijack_small.png", -- NEEDS TO BE CUSTOM!!!!!!!!
 
 		-- Note that abilityOwner is the drone, unit is the agent!
@@ -39,10 +39,10 @@ local MM_renameDrone =
 			    return targets.unitTarget( game, { abilityOwner }, self, abilityOwner, unit )
             end
 		end,
-		
+
 		-- Current acquireTargets allows diagonal petting, which crashes due to lack of diagonal animation.
 		-- Needs to be adapted to only allow orthogonal petting. Below example code taken from melee.acquireTargets.
-		
+
 		-- acquireTargets = function( self, targets, game, sim, unit )
 			-- -- Check adjacent tiles
 			-- local targetUnits = {}
@@ -76,7 +76,7 @@ local MM_renameDrone =
 			if unit:getTraits().hasAlreadyPetDrone then
 				return false
 			end
-			
+
             return true
 		end,
 
@@ -85,12 +85,12 @@ local MM_renameDrone =
 			local x1, y1 = abilityOwner:getLocation()
 
 			local facing = simquery.getDirectionFromDelta( x1 - x0, y1 - y0 )
-			
+
 			local droneSounds = {abilityOwner:getSounds().getko, abilityOwner:getSounds().getko, abilityOwner:getSounds().reboot_end}
-			local droneSound = droneSounds[sim:nextRand(1, #droneSounds)]			
+			local droneSound = droneSounds[sim:nextRand(1, #droneSounds)]
 
 			sim:dispatchEvent( simdefs.EV_UNIT_USEDOOR, { unitID = unit:getID(), facing = facing, sound = nil, soundFrame = 1 } )
-			
+
 			sim:dispatchEvent( simdefs.EV_PLAY_SOUND, {sound=droneSound, x=x0,y=y0} )
 			sim:dispatchEvent( simdefs.EV_UNIT_USEDOOR_PST, { unitID = unit:getID(), facing = facing } )
 
@@ -99,11 +99,11 @@ local MM_renameDrone =
 
 			sim:dispatchEvent( simdefs.EV_GAIN_AP, { unit = unit } )
 			sim:dispatchEvent( simdefs.EV_UNIT_FLOAT_TXT, {txt=STRINGS.UI.FLY_TXT.MOVEMENT_BOOSTED,x=x0,y=y0,color={r=1,g=1,b=1,a=1}} )
-			
+
 			unit:getTraits().hasAlreadyPetDrone = true
-			
+
 
 		end,
 	}
-	
+
 return MM_renameDrone

--- a/scripts/abilities/MM_renameDrone.lua
+++ b/scripts/abilities/MM_renameDrone.lua
@@ -5,7 +5,7 @@ local simdefs = include("sim/simdefs")
 local simquery = include("sim/simquery")
 local abilityutil = include( "sim/abilities/abilityutil" )
 
-local MM_renameDrone = 
+local MM_renameDrone =
 	{
 		name = STRINGS.MOREMISSIONS.ABILITIES.RENAME_DRONE,
 
@@ -19,19 +19,19 @@ local MM_renameDrone =
 			end
 			if unit:getTraits().activate_txt_body then
 				body = unit:getTraits().activate_txt_body
-			end			
+			end
 
 			return abilityutil.formatToolTip( title,  body )
 		end,
-		
+
 		proxy = true,
 		HUDpriority = 1,
 		getName = function( self, sim, abilityOwner, abilityUser, targetUnitID )
 			return self.name
 		end,
-		
+
 		profile_icon = "gui/icons/action_icons/Action_icon_Small/icon-item_hijack_small.png",
-		
+
 		-- NEEDS FIXING TO DISALLOW DIAGONAL INTERACTION
 		acquireTargets = function( self, targets, game, sim, abilityOwner, unit )
             if simquery.canUnitReach( sim, unit, abilityOwner:getLocation() ) and (unit ~= abilityOwner) then
@@ -43,12 +43,12 @@ local MM_renameDrone =
 			if abilityOwner == unit then
 				return false
 			end
-			
+
 			if abilityOwner:getTraits().alreadyRenamed then
 				return false
 			end
 
-            return true
+            return true -- simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
 		end,
 
 		executeAbility = function( self, sim, abilityOwner, unit )
@@ -60,10 +60,10 @@ local MM_renameDrone =
 			sim:dispatchEvent( simdefs.EV_UNIT_USECOMP, { unitID = unit:getID(), targetID= abilityOwner:getID(), facing = facing, sound=simdefs.SOUNDPATH_USE_CONSOLE, soundFrame=10 } )
 
 			local result = sim:dispatchChoiceEvent( "NameDialog" )
-			abilityOwner:getTraits().customName = result.txt	
+			abilityOwner:getTraits().customName = result.txt
 			abilityOwner:getTraits().alreadyRenamed = true
 
 		end,
 	}
-	
+
 return MM_renameDrone

--- a/scripts/abilities/MM_renameDrone.lua
+++ b/scripts/abilities/MM_renameDrone.lua
@@ -32,13 +32,6 @@ local MM_renameDrone =
 
 		profile_icon = "gui/icons/action_icons/Action_icon_Small/icon-item_hijack_small.png",
 
-		-- NEEDS FIXING TO DISALLOW DIAGONAL INTERACTION
-		acquireTargets = function( self, targets, game, sim, abilityOwner, unit )
-            if simquery.canUnitReach( sim, unit, abilityOwner:getLocation() ) and (unit ~= abilityOwner) then
-			    return targets.unitTarget( game, { abilityOwner }, self, abilityOwner, unit )
-            end
-		end,
-
 		canUseAbility = function( self, sim, abilityOwner, unit )
 			if abilityOwner == unit then
 				return false
@@ -48,7 +41,7 @@ local MM_renameDrone =
 				return false
 			end
 
-            return true -- simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
+            return simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
 		end,
 
 		executeAbility = function( self, sim, abilityOwner, unit )


### PR DESCRIPTION
Fixes #184 

`proxy = true` already enables the ability when an agent is within 2 tiles by taxicab distance. `acquireTargets` is unnecessary, and the `canUnitReach` check can be the final result of `canUseAbility`.