### PR TITLE
Assorted Refit Drone Friend fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include makeconfig.mk
 
 ensuredir = @mkdir -p $(@D)
 
-files := modinfo.txt scripts.zip gui.kwad moremissions_anims.kwad sound.kwad pedler_oil.kwad
+files := modinfo.txt scripts.zip gui.kwad moremissions_anims.kwad sound.kwad oil_fx.kwad
 outfiles := $(addprefix out/, $(files))
 installfiles := $(addprefix $(INSTALL_PATH)/, $(files))
 ifneq ($(INSTALL_PATH2),)
@@ -68,9 +68,9 @@ out/gui.kwad out/moremissions_anims.kwad out/sound.kwad: $(anims) $(guis) $(soun
 	mkdir -p out
 	$(KWAD_BUILDER) -i build.lua -o out
 
-out/pedler_oil.kwad: pedler_oil.kwad
+out/oil_fx.kwad: oil_fx.kwad
 	$(ensuredir)
-	cp pedler_oil.kwad out/pedler_oil.kwad
+	cp oil_fx.kwad out/oil_fx.kwad
 
 #
 # scripts

--- a/Makefile
+++ b/Makefile
@@ -8,28 +8,33 @@
 
 include makeconfig.mk
 
-.PHONY: build
+.PHONY: build install clean distclean cleanOut
+.SECONDEXPANSION:
 
-build: out/scripts.zip out/gui.kwad out/moremissions_anims.kwad out/sound.kwad out/modinfo.txt
+ensuredir = @mkdir -p $(@D)
 
-install: build
-	mkdir -p $(INSTALL_PATH)
-	rm -f $(INSTALL_PATH)/*.kwad $(INSTALL_PATH)/*.zip
-	cp out/modinfo.txt $(INSTALL_PATH)/
-	cp out/scripts.zip $(INSTALL_PATH)/
-	cp out/gui.kwad $(INSTALL_PATH)/
-	cp out/moremissions_anims.kwad $(INSTALL_PATH)/
-	cp out/sound.kwad $(INSTALL_PATH)/
-	cp pedler_oil.kwad $(INSTALL_PATH)/
+files := modinfo.txt scripts.zip gui.kwad moremissions_anims.kwad sound.kwad pedler_oil.kwad
+outfiles := $(addprefix out/, $(files))
+installfiles := $(addprefix $(INSTALL_PATH)/, $(files))
 ifneq ($(INSTALL_PATH2),)
-	mkdir -p $(INSTALL_PATH2)
-	rm -f $(INSTALL_PATH2)/*.kwad $(INSTALL_PATH2)/*.zip
-	cp out/modinfo.txt $(INSTALL_PATH2)/
-	cp out/scripts.zip $(INSTALL_PATH2)/
-	cp pedler_oil.kwad $(INSTALL_PATH2)/
-	cp out/gui.kwad $(INSTALL_PATH2)/
-	cp out/moremissions_anims.kwad $(INSTALL_PATH2)/
-	cp out/sound.kwad $(INSTALL_PATH2)/
+	installfiles += $(addprefix $(INSTALL_PATH2)/, $(files))
+endif
+
+build: $(outfiles)
+install: build $(installfiles)
+
+$(installfiles): %: out/$$(@F)
+	$(ensuredir)
+	cp $< $@
+
+clean: cleanOut
+cleanOut:
+	-rm out/*
+
+distclean:
+	-rm -f $(INSTALL_PATH)/*.kwad $(INSTALL_PATH)/*.zip
+ifneq ($(INSTALL_PATH2),)
+	-rm -f $(INSTALL_PATH2)/*.kwad $(INSTALL_PATH2)/*.zip
 endif
 
 rar: build
@@ -62,6 +67,10 @@ $(anims): %.anim: $(wildcard %.anim.d/*.xml $.anim.d/*.png)
 out/gui.kwad out/moremissions_anims.kwad out/sound.kwad: $(anims) $(guis) $(sounds)
 	mkdir -p out
 	$(KWAD_BUILDER) -i build.lua -o out
+
+out/pedler_oil.kwad: pedler_oil.kwad
+	$(ensuredir)
+	cp pedler_oil.kwad out/pedler_oil.kwad
 
 #
 # scripts

--- a/scripts/abilities/MM_petDrone.lua
+++ b/scripts/abilities/MM_petDrone.lua
@@ -47,7 +47,8 @@ local MM_petDrone =
 				body = body .. "\n<c:ff0000>" .. reason .. "</>"
 			end
 
-			return pet_tooltip( hud, abilityUser, self.ap_boost, title,  body )
+			local previewAPBoost = self._shouldShowAPBonus and self.ap_boost or 0
+			return pet_tooltip( hud, abilityUser, previewAPBoost, title,  body )
 		end,
 
 		proxy = true,
@@ -58,6 +59,13 @@ local MM_petDrone =
 		end,
 
 		profile_icon = "gui/icons/action_icons/Action_icon_Small/icon-action_pet_drone.png",
+
+		onSpawnAbility = function( self )
+			-- Use a settings 'seenOnce', to store if the user has ever pet a drone before.
+			-- The AP Bonus UI preview is suppressed until the ability's effect has been seen.
+			local settings = savefiles.getSettings( "settings" )
+			self._shouldShowAPBonus = settings.data.seenOnce[ "MM-petDrone-AP" ]
+		end,
 
 		-- Note that abilityOwner is the drone, unit is the agent!
 		canUseAbility = function( self, sim, abilityOwner, unit )
@@ -101,7 +109,13 @@ local MM_petDrone =
 
 			unit:getTraits().hasAlreadyPetDrone = true
 
-
+			if not self._shouldShowAPBonus then
+				-- Player has seen the AP boost. The UI may now show it on other agents or in future games.
+				local settings = savefiles.getSettings( "settings" )
+				self._shouldShowAPBonus = true
+				settings.data.seenOnce[ "MM-petDrone-AP" ] = true
+				settings:save()
+			end
 		end,
 	}
 

--- a/scripts/abilities/MM_petDrone.lua
+++ b/scripts/abilities/MM_petDrone.lua
@@ -5,9 +5,9 @@ local simdefs = include("sim/simdefs")
 local simquery = include("sim/simquery")
 local abilityutil = include( "sim/abilities/abilityutil" )
 
-local MM_renameDrone =
+local MM_petDrone =
 	{
-		name = STRINGS.MOREMISSIONS.ABILITIES.RENAME_DRONE,
+		name = STRINGS.MOREMISSIONS.ABILITIES.PET_DRONE,
 
 		createToolTip = function( self, sim, unit )
 
@@ -43,7 +43,14 @@ local MM_renameDrone =
 				return false
 			end
 
-            return simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
+			-- canUnitReach reports BLOCKED or OUT OF REACH even if there's a wall in the way so rule that out first.
+			-- But we want the OUT OF REACH message to help users discover this ability.
+			local agentCell = sim:getCell(unit:getLocation())
+			local droneCell = sim:getCell(abilityOwner:getLocation())
+			if not simquery.canPathBetween(sim, unit, agentCell, droneCell) then
+				return false
+			end
+			return simquery.canUnitReach(sim, unit, droneCell.x, droneCell.y)
 		end,
 
 		executeAbility = function( self, sim, abilityOwner, unit )
@@ -72,4 +79,4 @@ local MM_renameDrone =
 		end,
 	}
 
-return MM_renameDrone
+return MM_petDrone

--- a/scripts/abilities/MM_petDrone.lua
+++ b/scripts/abilities/MM_petDrone.lua
@@ -50,7 +50,8 @@ local MM_petDrone =
 			-- Use a settings 'seenOnce', to store if the user has ever pet a drone before.
 			-- The AP Bonus UI preview is suppressed until the ability's effect has been seen.
 			local settings = savefiles.getSettings( "settings" )
-			self._shouldShowAPBonus = settings.data.seenOnce[ "MM-petDrone-AP" ]
+			local seenOnce = settings.data.seenOnce or {}
+			self._shouldShowAPBonus = seenOnce[ "MM-petDrone-AP" ]
 		end,
 
 		-- Note that abilityOwner is the drone, unit is the agent!
@@ -98,8 +99,9 @@ local MM_petDrone =
 			if not self._shouldShowAPBonus then
 				-- Player has seen the AP boost. The UI may now show it on other agents or in future games.
 				local settings = savefiles.getSettings( "settings" )
-				self._shouldShowAPBonus = true
+				settings.data.seenOnce = settings.data.seenOnce or {}
 				settings.data.seenOnce[ "MM-petDrone-AP" ] = true
+				self._shouldShowAPBonus = true
 				settings:save()
 			end
 		end,

--- a/scripts/abilities/MM_renameDrone.lua
+++ b/scripts/abilities/MM_renameDrone.lua
@@ -41,7 +41,12 @@ local MM_renameDrone =
 				return false
 			end
 
-            return simquery.canUnitReach(sim, unit, abilityOwner:getLocation())
+			-- Only report true if agent is adjacent, swallowing errors otherwise.
+			-- MM_petDrone can handle the error messages for almost-but-not-quite-reachable.
+			if simquery.canUnitReach(sim, unit, abilityOwner:getLocation()) then
+				return true
+			end
+			return false
 		end,
 
 		executeAbility = function( self, sim, abilityOwner, unit )

--- a/scripts/agentdefs.lua
+++ b/scripts/agentdefs.lua
@@ -226,6 +226,7 @@ local agent_templates =
 			hasHearing = false,
 			pacifist = true,
 			dynamicImpass = false,
+			MM_agencyDynamicNonImpass = true, -- Prevents pathing through lethal lasers
 			augmentMaxSize = 0,
 			isAiming = false,
 			noUpgrade = true,

--- a/scripts/agentdefs.lua
+++ b/scripts/agentdefs.lua
@@ -231,7 +231,6 @@ local agent_templates =
 			noUpgrade = true,
 			dashSoundRange = 0,
 			noLoopOverwatch = true,
-			isAiming = true,
 			mainframe_no_daemon_spawn = true,
 			lookaroundRange = 4,
 			PWROnHand = 0,

--- a/scripts/agentdefs.lua
+++ b/scripts/agentdefs.lua
@@ -236,10 +236,10 @@ local agent_templates =
 			PWROnHand = 0,
 			scanSweeps = true,
 			cant_abandon = true,
-			hidesInCover = true, --false,
+			hidesInCover = true, -- If setting back to false, uncomment doesNotHideInCover for the tooltip.
 			-- doesNotHideInCover = true, --for tooltip
 			refitDroneFriend = true,
-			-- disguiseOn = true,
+			-- disguiseOn = true, -- If uncommenting, update "REPROGRAMMED" string description.
 		},
 		fullname = STRINGS.AGENTS.HOSTAGE.ALT_1.FULLNAME,
 		yearsOfService = STRINGS.AGENTS.HOSTAGE.YEARS_OF_SERVICE,

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -920,7 +920,7 @@ return {
 			USB_PROGRAM_STORED = "PROGRAM STORED: {1}",
 			
 			REPROGRAMMED = "REPROGRAMMED",
-			REPROGRAMMED_DESC = "This Refit Drone is under Agency control.",
+			REPROGRAMMED_DESC = "This Refit Drone is under Agency control. Uses cover, but is NOT considered friendly by guards.",
 			
 			LEAVES_AT_END = "FRAGILE CASING",
 			LEAVES_AT_END_DESC = "Will be retired to the jet after this mission.",

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -920,7 +920,7 @@ return {
 			USB_PROGRAM_STORED = "PROGRAM STORED: {1}",
 			
 			REPROGRAMMED = "REPROGRAMMED",
-			REPROGRAMMED_DESC = "This Refit Drone is under Agency control. Uses cover, but is NOT considered friendly by guards.",
+			REPROGRAMMED_DESC = "This Refit Drone is under Agency control. Uses cover. Is NOT considered friendly by guards.",
 			
 			LEAVES_AT_END = "FRAGILE CASING",
 			LEAVES_AT_END_DESC = "Will be retired to the jet after this mission.",


### PR DESCRIPTION
### Major fixes/tweaks

* Hide "BLOCKED" pet drone ability icon when on the other side of a wall. Retain the "OUT OF RANGE" icon state when within 2 tiles and "BLOCKED" when on the other side of a door. These will help players discover that they _can_ pet their drone friends.
* Hide rename drone ability icon when blocked or out of range. Pet drone is enough for discoverability. No need for two icons.
* Prevent drone friend from attempting to path through lethal lasers.
* Add "Uses cover, but is NOT considered friendly by guards" to the REPROGRAMMED tooltip line. These seem to be the main questions from new players of the mod.

Fixes #200 
Fixes #213 

### Minor fixes/tweaks

* Don't spawn with the overwatch trait set to true. (It's cleared on movement and has no effect besides.) This becomes visible and confusing with new/upcoming UITR status lights for ambush/overwatch.
* Preview the 1AP boost when hovering the pet drone ability.
     * If we want to preserve the surprise, I can revert this change individually.

### Unrelated tweaks

* Copy improvements to the Makefile from UITR. It avoids copying files unnecessarily and makes it easier to add new files to the build.