### PR TITLE
Fix excessive Courier Rescue loading time

### DIFF
--- a/scripts/missions/ea_hostage.lua
+++ b/scripts/missions/ea_hostage.lua
@@ -686,6 +686,16 @@ local function startPhase( script, sim )
 	-- sim:getTags().delayPostGame = false
 end
 
+local function hostageFitness(cxt, prefab, x, y)
+    local tileCount = cxt:calculatePrefabLinkage(prefab, x, y)
+    if tileCount == 0 then
+        return 0
+    end
+
+    -- mission_util.calculatePrefabDistance is searching for a string in the filename, so the endless exit is already included
+    local maxDist = mission_util.calculatePrefabDistance(cxt, x, y, "entry", "exit")
+    return tileCount + maxDist ^ 2
+end
 
 ---------------------------------------------------------------------------------------------
 -- Begin!
@@ -722,9 +732,16 @@ function hostage_mission:init( scriptMgr, sim )
 
 end
 
-function hostage_mission.pregeneratePrefabs( cxt, tagSet ) 	-- was tags instead of tagSet
-	escape_mission.pregeneratePrefabs( cxt, tagSet ) 	-- added
-	table.insert( tagSet[1], "hostage" )
+function hostage_mission.pregeneratePrefabs( cxt, tagSet )
+	local prefabs = include("sim/prefabs")
+	escape_mission.pregeneratePrefabs( cxt, tagSet )
+	-- tagSet[1].fitnessSelect = prefabs.SELECT_HIGHEST -- not sure why this is in vanilla, it just maximises tilecount between the default room prefabs
+    table.insert(
+        tagSet, {
+            {"hostage", hostageFitness},
+            fitnessSelect = prefabs.SELECT_HIGHEST
+        }
+    )
 end
 
 function hostage_mission.generatePrefabs( cxt, candidates )
@@ -738,22 +755,6 @@ function hostage_mission.generatePrefabs( cxt, candidates )
             mod.generatePrefabs( cxt, candidates )
         end
     end
-end
-
-
-
-function hostage_mission.finalizeProcgen( cxt )
-	local hostageUnit = cxt:pickUnit( function(u) return u.template == "MM_hostage_capture_ea" end )
-	local startX, startY = cxt:pickCell( cxt.IS_DEPLOY_CELL )
-	local exitX, exitY = cxt:pickCell( cxt.IS_EXIT_CELL )
-	log:write( "FINALIZE: hostage@ <%d, %d>, start<%d, %d>, end<%d, %d>", hostageUnit.x, hostageUnit.y, startX, startY, exitX, exitY )
-	local p0 = cxt:findPath( startX, startY, hostageUnit.x, hostageUnit.y )
-	local p1 = cxt:findPath( hostageUnit.x, hostageUnit.y, exitX, exitY )
-	local rlen = mathutil.dist2d( 0, 0, cxt.board.width, cxt.board.height ) * 2.5
-	local len0 = p0 and p0:getTotalMoveCost() or -1
-	local len1 = p1 and p1:getTotalMoveCost() or -1
-	log:write( "\tPATH TO HOSTAGE ( %d ) + PATH TO EXIT( %d ) == %d >= %d (%.2f)", len0, len1, len0 + len1, rlen, (len0 + len1) / rlen )
-	return (len0 + len1) / rlen
 end
 
 return hostage_mission


### PR DESCRIPTION
The Courier Rescue's finalizeProcgen script is currently forcing the entire level generation to run 12 times (The maximum; I have never seen it produce passing score) to get the best entry -> hostage -> exit distance. Which is very inefficient and explains the long loading time of that mission that most people playing it will probably have noticed. The game doesn't use finalizeProcgen anywhere anymore and I think Shirsh just copied this code in from the original EA mission.
It's a much better solution to rig the generation itself like the detention center and distress signal missions already do with a fitness function, than to run the entire level generation process over and over until it randomly produces a good score (or in this case, to force 11 passes and pick the best one).

So I just copied the code from the detention center over (like we already do for the distress call); it achieves the same thing without the excessive loading time.
I commented out the updated fitnessSelect for the first pass in tagSet from vanilla though because I don't see the point in further maximising the tileCount between the default room prefabs in that pass (entry, exit, structs).