### PR TITLE
Fix long lines being cut off

### DIFF
--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -2,6 +2,120 @@ local cdefs = include( "client_defs" )
 local rig_util = include( "gameplay/rig_util" )
 local talkinghead_ingame = include( "client/fe/talkinghead_ingame" )
 
+local ShowLine = talkinghead_ingame.ShowLine
+talkinghead_ingame.ShowLine = function(self, idx, ...)
+	if not self.script[idx].MM_script then
+		return ShowLine(self, idx, ...)
+	end
+
+	self.line_idx = idx
+
+	if self._scriptThread then
+		self._scriptThread:stop()
+		self._scriptThread = nil
+	end
+
+	self:StopLine(self)
+
+	local line = self.script[idx]
+	self.line = line
+
+	local was_viz = self.widget:isVisible()
+	if (self:shouldShowSubtitles() or not line.voice) and (not self.ismainframefn or not self.ismainframefn()) then
+		self.widget:setVisible(true)
+	else
+		self.widget:setVisible(false)
+	end
+
+	local playing_voice = false
+	if line.voice then
+		MOAIFmodDesigner.playSound(line.voice, "talkinghead_voice")
+		playing_voice = MOAIFmodDesigner.isPlaying("talkinghead_voice")
+	else
+		MOAIFmodDesigner.playSound("SpySociety/HUD/gameplay/Operator/textbox")
+	end
+
+	if
+		self.widget:isVisible()
+		and (not was_viz or line.anim ~= self.talking_head_anim or self.line_idx == 1)
+		and not self.widget:hasTransition()
+	then
+		self.widget:createTransition("activate_left")
+	end
+	self.talking_head_anim = line.anim
+
+	self.widget.binder.profileAnim:bindBuild(line.build or line.anim)
+	self.widget.binder.profileAnim:bindAnim(line.anim)
+	if line.name then
+		self.widget.binder.headerTxt:setText(line.name .. ":")
+	else
+		self.widget.binder.headerTxt:setText("")
+	end
+
+	-- new code starts here
+	local lbl = self.widget.binder.bodyTxt
+	-- why was this faster with no voice? makes no sense to me
+	lbl:spoolText(line.text, 30) -- line.voice and 30 or 60)
+	self._typeThread = MOAICoroutine.new()
+	self._typeThread:run(function()
+		while true do
+			lbl._cont:getProp():spool()
+			while lbl:isSpooling() do
+				coroutine.yield()
+			end
+			rig_util.wait(2.5 * cdefs.SECONDS)
+			if lbl:hasNextPage() then
+				lbl:nextPage()
+			else
+				break
+			end
+		end
+		self._typeThread = nil
+	end)
+
+	if self.line_idx < #self.script then
+		self._scriptThread = MOAICoroutine.new()
+		self._scriptThread:run(function()
+			if playing_voice then
+				while MOAIFmodDesigner.isPlaying("talkinghead_voice") do
+					coroutine.yield()
+				end
+				rig_util.wait(0.2 * cdefs.SECONDS)
+			else
+				-- wait for typethread to terminate instead of a fixed amount of time
+				while self._typeThread ~= nil do
+					coroutine.yield()
+				end
+			end
+
+			self:ShowLine(self.line_idx + 1)
+		end)
+	elseif self.line_idx >= #self.script then
+		self._scriptThread = MOAICoroutine.new()
+		self._scriptThread:run(function()
+			if playing_voice then
+				while MOAIFmodDesigner.isPlaying("talkinghead_voice") do
+					coroutine.yield()
+				end
+				rig_util.wait(0.2 * cdefs.SECONDS)
+			else
+				-- wait for typethread to terminate instead of a fixed amount of time
+				while self._typeThread ~= nil do
+					coroutine.yield()
+				end
+			end
+
+			if self.onfinished then
+				self.onfinished()
+			end
+			self:Halt()
+			self.isdone = true
+		end)
+	end
+end
+
+--[[ -- prevent Operator messages during mainframe mode, if we want this
+
 --by Cyberboy2000
 
 local oldShowLine = talkinghead_ingame.ShowLine
@@ -30,4 +144,5 @@ function talkinghead_ingame:ShowLine(idx)
     end
     
     oldShowLine(self, idx)
-end
+
+end ]]--

--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -5,9 +5,9 @@ local talkinghead_ingame = include( "client/fe/talkinghead_ingame" )
 local ShowLine = talkinghead_ingame.ShowLine
 talkinghead_ingame.ShowLine = function(self, idx, ...)
 	-- bug fix for all scripts: wait for the previous script to fade out so
-	-- the new one doesn't disappear immediately
-	while self.widget:hasTransition() do
-		coroutine.yield()
+	-- the new one doesn't disappear immediately (this only seems to happen after TA oneliners?)
+	if self.widget:hasTransition() then
+		self.widget:clearTransition()
 	end
 
 	-- leave other scripts unchanged
@@ -178,6 +178,7 @@ function talkinghead_ingame:ShowLine(idx)
     oldShowLine(self, idx)
 
 end ]]--
+
 
 
 

--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -61,10 +61,14 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 	-- text is too long to display in a single text box
 	self._typeThread:run(function()
 		while true do
+			if not playing_voice then
+				MOAIFmodDesigner.playSound("SpySociety/HUD/menu/text_print_2_LP", "MM_talkinghead_type")
+			end
 			lbl._cont:getProp():spool()
 			while lbl:isSpooling() do
 				coroutine.yield()
 			end
+			MOAIFmodDesigner.stopSound("MM_talkinghead_type")
 			rig_util.wait(2.5 * cdefs.SECONDS)
 			if lbl:hasNextPage() then
 				lbl:nextPage()
@@ -118,6 +122,12 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 	end
 end
 
+local StopLine = talkinghead_ingame.StopLine
+talkinghead_ingame.StopLine = function(self, ...)
+	MOAIFmodDesigner.stopSound("MM_talkinghead_type")
+	StopLine(self, ...)
+end
+
 --[[ -- prevent Operator messages during mainframe mode, if we want this
 
 --by Cyberboy2000
@@ -150,4 +160,5 @@ function talkinghead_ingame:ShowLine(idx)
     oldShowLine(self, idx)
 
 end ]]--
+
 

--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -4,7 +4,7 @@ local talkinghead_ingame = include( "client/fe/talkinghead_ingame" )
 
 local ShowLine = talkinghead_ingame.ShowLine
 talkinghead_ingame.ShowLine = function(self, idx, ...)
-	-- bug fix for all scripts: wait for the previous script to fade out so
+	-- bug fix for all scripts: clear the previous script to fade out so
 	-- the new one doesn't disappear immediately (this only seems to happen after TA oneliners?)
 	if self.widget:hasTransition() then
 		self.widget:clearTransition()
@@ -178,6 +178,7 @@ function talkinghead_ingame:ShowLine(idx)
     oldShowLine(self, idx)
 
 end ]]--
+
 
 
 

--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -4,6 +4,13 @@ local talkinghead_ingame = include( "client/fe/talkinghead_ingame" )
 
 local ShowLine = talkinghead_ingame.ShowLine
 talkinghead_ingame.ShowLine = function(self, idx, ...)
+	-- bug fix for all scripts: wait for the previous script to fade out so
+	-- the new one doesn't disappear immediately
+	while self.widget:hasTransition() do
+		coroutine.yield()
+	end
+
+	-- leave other scripts unchanged
 	if not self.script[idx].MM_script then
 		return ShowLine(self, idx, ...)
 	end
@@ -54,24 +61,35 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 
 	-- new code starts here
 	local lbl = self.widget.binder.bodyTxt
-	-- why was this faster with no voice? makes no sense to me
-	lbl:spoolText(line.text, 30) -- line.voice and 30 or 60)
+	lbl:spoolText(line.text, line.spoolSpeed or 30) -- added optional spoolspeed
 	self._typeThread = MOAICoroutine.new()
 	-- changed so it automatically turns the page after finishing the spool if the
 	-- text is too long to display in a single text box
 	self._typeThread:run(function()
+		local page = 1
 		while true do
+			local frames = 0
 			if not playing_voice then
 				MOAIFmodDesigner.playSound("SpySociety/HUD/menu/text_print_2_LP", "MM_talkinghead_type")
 			end
 			lbl._cont:getProp():spool()
 			while lbl:isSpooling() do
+				frames = frames + 1
 				coroutine.yield()
 			end
 			MOAIFmodDesigner.stopSound("MM_talkinghead_type")
-			rig_util.wait(2.5 * cdefs.SECONDS)
+			-- optional delay before turning the page
+			if line.pageDelay and line.pageDelay[page] then
+				local delay = line.pageDelay[page] * cdefs.SECONDS - frames
+				if delay > 0 then
+					rig_util.wait(delay)
+				end
+			else
+				rig_util.wait(2.5 * cdefs.SECONDS)
+			end
 			if lbl:hasNextPage() then
 				lbl:nextPage()
+				page = page + 1
 			else
 				break
 			end
@@ -160,5 +178,6 @@ function talkinghead_ingame:ShowLine(idx)
     oldShowLine(self, idx)
 
 end ]]--
+
 
 

--- a/scripts/appended_functions/talkingheadfix.lua
+++ b/scripts/appended_functions/talkingheadfix.lua
@@ -57,6 +57,8 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 	-- why was this faster with no voice? makes no sense to me
 	lbl:spoolText(line.text, 30) -- line.voice and 30 or 60)
 	self._typeThread = MOAICoroutine.new()
+	-- changed so it automatically turns the page after finishing the spool if the
+	-- text is too long to display in a single text box
 	self._typeThread:run(function()
 		while true do
 			lbl._cont:getProp():spool()
@@ -83,6 +85,7 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 				rig_util.wait(0.2 * cdefs.SECONDS)
 			else
 				-- wait for typethread to terminate instead of a fixed amount of time
+				-- (setting line.timing no longer does anything)
 				while self._typeThread ~= nil do
 					coroutine.yield()
 				end
@@ -100,6 +103,7 @@ talkinghead_ingame.ShowLine = function(self, idx, ...)
 				rig_util.wait(0.2 * cdefs.SECONDS)
 			else
 				-- wait for typethread to terminate instead of a fixed amount of time
+				-- (setting line.timing no longer does anything)
 				while self._typeThread ~= nil do
 					coroutine.yield()
 				end
@@ -146,3 +150,4 @@ function talkinghead_ingame:ShowLine(idx)
     oldShowLine(self, idx)
 
 end ]]--
+

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -58,6 +58,8 @@ local function earlyInit( modApi )
 
 	local serverdefs = include( "modules/serverdefs" )
 	default_missiontags = array.copy(serverdefs.ESCAPE_MISSION_TAGS)
+
+	include( scriptPath .. "/appended_functions/talkingheadfix") -- semi-override
 end
 
 local function init( modApi )
@@ -157,8 +159,6 @@ end
 local function lateInit( modApi )
 	local dataPath = modApi:getDataPath()
 	local scriptPath = modApi:getScriptPath()
-	
-	-- include( scriptPath .. "/appended_functions/talkingheadfix") -- prevent Operator messages during mainframe mode, if we want this
 	
 	-- MOLE_INSERTION
 	-- custom intelligence benefit

--- a/scripts/story_scripts.lua
+++ b/scripts/story_scripts.lua
@@ -1,15 +1,14 @@
 -- local SCRIPTS = include('client/story_scripts')
 local util = include( "modules/util" )
-local message_time = 8 --use the same message delay for all messages for now
 
 local MakeLine = {
-	Central = function(t, text, voice, timing)
+	Central = function(t, text, voice)
 		t.text = text
         t.anim = "portraits/central_face"
         t.name = STRINGS.UI.CENTRAL_TITLE
         t.voice = voice
-        t.timing = timing --only used in vanilla for the two-part cyberlab judgement
         t.delay = 0.25
+		t.MM_script = true
 	end,
 	Monster = function(t, text, voice)
 		t.text = text
@@ -17,6 +16,7 @@ local MakeLine = {
         t.name = STRINGS.UI.MONST3R_TITLE
 		t.voice = voice
 		t.delay = 0.25
+		t.MM_script = true
 	end,
 	Incognita = function(t, text, voice)
 		t.text = text
@@ -24,6 +24,7 @@ local MakeLine = {
 		t.name = STRINGS.UI.INCOGNITA_TITLE
 		t.voice = voice
 		t.delay = 0.25
+		t.MM_script = true
 	end,
 }
 
@@ -34,7 +35,7 @@ local function GenerateScript(strings, scripts)
 			log:write("[MM] Warning: The following Story Script had no valid actor (" .. util.stringize(strings[3], 1) .. "):\n" .. strings[1])
 			strings[3] = "Central"
 		end
-		MakeLine[strings[3]](scripts, strings[1], strings[2], message_time)
+		MakeLine[strings[3]](scripts, strings[1], strings[2])
 	else
 		for i, data in pairs(strings) do
 			if type(data) == "table" then

--- a/scripts/story_scripts.lua
+++ b/scripts/story_scripts.lua
@@ -2,28 +2,34 @@
 local util = include( "modules/util" )
 
 local MakeLine = {
-	Central = function(t, text, voice)
+	Central = function(t, text, voice, pageDelay, spoolSpeed)
 		t.text = text
-        t.anim = "portraits/central_face"
-        t.name = STRINGS.UI.CENTRAL_TITLE
-        t.voice = voice
-        t.delay = 0.25
-		t.MM_script = true
-	end,
-	Monster = function(t, text, voice)
-		t.text = text
-        t.anim = "portraits/monst3r_face"
-        t.name = STRINGS.UI.MONST3R_TITLE
+		t.anim = "portraits/central_face"
+		t.name = STRINGS.UI.CENTRAL_TITLE
 		t.voice = voice
 		t.delay = 0.25
+		t.pageDelay = pageDelay -- table with page as key and delay in seconds as value
+		t.spoolSpeed = spoolSpeed -- 30 is default
 		t.MM_script = true
 	end,
-	Incognita = function(t, text, voice)
+	Monster = function(t, text, voice, pageDelay, spoolSpeed)
+		t.text = text
+		t.anim = "portraits/monst3r_face"
+		t.name = STRINGS.UI.MONST3R_TITLE
+		t.voice = voice
+		t.delay = 0.25
+		t.pageDelay = pageDelay
+		t.spoolSpeed = spoolSpeed
+		t.MM_script = true
+	end,
+	Incognita = function(t, text, voice, pageDelay, spoolSpeed)
 		t.text = text
 		t.anim = "portraits/incognita_face"
 		t.name = STRINGS.UI.INCOGNITA_TITLE
 		t.voice = voice
 		t.delay = 0.25
+		t.pageDelay = pageDelay
+		t.spoolSpeed = spoolSpeed
 		t.MM_script = true
 	end,
 }
@@ -35,7 +41,7 @@ local function GenerateScript(strings, scripts)
 			log:write("[MM] Warning: The following Story Script had no valid actor (" .. util.stringize(strings[3], 1) .. "):\n" .. strings[1])
 			strings[3] = "Central"
 		end
-		MakeLine[strings[3]](scripts, strings[1], strings[2])
+		MakeLine[strings[3]](scripts, strings[1], strings[2], strings[4], strings[5])
 	else
 		for i, data in pairs(strings) do
 			if type(data) == "table" then

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -1328,7 +1328,7 @@ return {
 							"Monster"},
 						{"Scrub the database or disrupt the device - a bullet or an EMP ought do the trick. They really don't use the most robust tech, I'm afraid. Now, if they had the benefit of a more reliable vendor-",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen1_2p",
-							"Monster"}, -- TODO: long line cut off. Missing "reliable vendor-"
+							"Monster"},
 						{"Derek, now is not the time.",
 							"moremissions/VoiceOver/Central/informant/shush_derek",
 							"Central"},
@@ -1346,12 +1346,11 @@ return {
 						{"Your other option is to locate a Camera Database and wipe the records remotely, but it's going to take time. Try to be a bit more subtle, will you? This is supposed to be a stealthy affair.",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen5_2p",
 							"Monster"}, -- Reuse this line from seen5, since this sequence didn't mention the DB option.
-							 -- TODO: long line cut off. Missing "stealthy affair, after all"
 					},
 					{
 						{"The visual feeds of all drones and cameras on this floor are synced up to a Camera Database. Get one of your people close to it, and you should be able to scrub their memory chips one by one.",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen2_1p",
-							"Monster"}, -- TODO: long line cut off. Missing "by one"
+							"Monster"},
 						{" Or... disrupt them through more physical means, if you prefer. Unlike Gladstone, I don't micromanage my allies nearly quite as heavily.",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen2_2p",
 							"Monster"},
@@ -1378,17 +1377,17 @@ return {
 					{
 						{"Seeing as you've let the informant be spotted, there are two ways to handle that. Destroy or EMP the device in question and it will scramble the visual chip enough to wipe the facial recognition records.",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen5_1p",
-							"Monster"}, -- TODO: long line cut off. Missing "recognition records"
+							"Monster"},
 						{"Your other option is to locate a Camera Database and wipe the records remotely, but it's going to take time. Try to be a bit more subtle, will you? This is supposed to be a stealthy affair, after all.",
 							"moremissions/VoiceOver/Monster/informant/witness_mainframe/seen5_2p",
-							"Monster"},  -- TODO: long line cut off. Missing "stealthy affair, after all"
+							"Monster"},
 					},
 				},
 				SEE_CAMERADB = {
 					{
 						{"There's a Camera Database. Be careful now - you can use this to wipe any camera and drone witnesses one by one, but it's quite the intrusive process. I have no doubt they will have countermeasures in place.",
 							"moremissions/VoiceOver/Monster/informant/sighted/camera_database1",
-							"Monster"}, -- TODO: long line cut off. Missing "countermeasures in place"
+							"Monster"},
 					},
 					{
 						{"A Camera Database. Keep that in mind, that may come in handy if our informant gets spotted by any pesky cameras or drones.",
@@ -1405,7 +1404,7 @@ return {
 					{
 						{"You've triggered a mainframe protocol, and it's restarting parts of the network as long as you're jacked into the camera feed. <sigh> I knew this would happen. Let's try to keep this intrusion brief, shall we?",
 							"moremissions/VoiceOver/Monster/informant/rebooting2",
-							"Monster"}, -- TODO: long line cut off. Missing "shall we"
+							"Monster"},
 					},
 				},
 				SEE_OBJECTIVE_DOOR = {
@@ -1622,7 +1621,7 @@ return {
 					STORAGE_SPOTTED_1 = {
 						{"Operator, our telemetry data suggests there are two more rooms like this somewhere in the facility. If we can spare the time, it would be a shame to leave these valuables without stopping by.",
 							nil,
-							"Central"}, -- TODO: long line cut off. Missing "stopping by"
+							"Central"},
 						{"Do try not to break them. My clients are incredibly particular about the number of pieces they prefer their merchandise to be in.",
 							"moremissions/VoiceOver/Monster/briefcases/sighted1_p2",
 							"Monster"},
@@ -1686,7 +1685,7 @@ return {
 --						{"There must be an activation key somewhere. See if you can find anything in the back room.",nil,"Central"},
 						{"Ahh, now that is interesting. This model of Nanofab is specialised in precisely one type of gear, but undergoes a lengthy recalibration process after each job. You'd best make your choice carefully.",
 							"moremissions/VoiceOver/Monster/luxury_nanofab/sighted_1p",
-							"Monster"}, -- TODO: long line cut off. Missing "choice carefully"
+							"Monster"},
 						{"Take a look around the back room - there should be a console to summon tech support in there, and they are bound to have access.",
 							"moremissions/VoiceOver/Monster/luxury_nanofab/sighted_2p",
 							"Monster"},
@@ -1696,7 +1695,7 @@ return {
 --						{"The key you looted off that guard should come in handy now. Time to see what the nanofab has in store for us.",nil,"Central"},
 						{"Ahh, now that is interesting. This model of Nanofab is specialised in precisely one type of gear, but undergoes a lengthy recalibration process after each job. You'd best make your choice carefully.",
 							"moremissions/VoiceOver/Monster/luxury_nanofab/sighted_1p",
-							"Monster"}, -- TODO: long line cut off. Missing "choice carefully"
+							"Monster"},
 						{"Now, I do believe you already have the key? Do you not?",
 							"moremissions/VoiceOver/Monster/luxury_nanofab/haskey",
 							"Monster"},


### PR DESCRIPTION
Fix #218 
Instead of manually correcting all lines that don't fit in the textbox, I changed it so it automatically turns the page after the text finished spooling. This can seperate sentences in a kind of ugly way but I still think it's a good solution.

I also changed some timing: The text display speed for no-voice lines is now the same as lines with voice and there is no longer a fixed wait time before the script is progressed. Instead it waits for the text to finish showing up and then continues after a short pause. So short text is displayed shorter and long text displayed longer (I noticed that very long text without voice disappeared too fast).