### PR TITLE
Fix decoy walking to a patrol point that doesn't exist

### DIFF
--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -1000,7 +1000,6 @@ local function spawnDecoy( sim, cell, facing )
 	sim:warpUnit( decoyUnit, cell )	
 	decoyUnit:setPather(sim:getNPC().pather)
 	decoyUnit:getBrain():setSituation(sim:getNPC():getIdleSituation() )
-	sim:getNPC():getIdleSituation():generatePatrolPath( decoyUnit, decoyUnit:getLocation() )
 	decoyUnit:getTraits().patrolPath = { { x = cell.x, y = cell.y, facing = facing } }
 	decoyUnit:getTraits().MM_decoy = true
 	decoyUnit:getTraits().MM_unsearchable = true


### PR DESCRIPTION
The new CBF feature that calls ``unit.updateFacing`` in ``idle.generatePatrolPath`` when called at the start of the sim will update the facing of the decoy as if they walked the patrol, which will tick their brain and make them calculate a path to the temporary patrol before we replace it the next line. Which then makes the decoy walk to a patrol point that no longer exists before going back to their stationary spot.
``decoyUnit:getTraits().patrolPath`` is getting overridden in the next line anyway so I don't get why we needed to call ``generatePatrolPath`` in the first place - there is nothing else happening inside that function that we need.