### PR TITLE
Fix suitcase hook recursion

### DIFF
--- a/scripts/escape_mission.lua
+++ b/scripts/escape_mission.lua
@@ -211,7 +211,6 @@ local function spottedStorage( script, sim )
 			script:addHook( spottedStorage )
 			script:queue( { type="hideHUDInstruction" } )
 		end
-		script:addHook( spottedStorage )
 	elseif sim:getPC():getTraits().W93_spottedStorage == 2 then
 		script:waitFor( PC_SAW_UNIT_WITH_MARKER2( script, "w93_storage_1", STRINGS.MOREMISSIONS.MISSIONS.SIDEMISSIONS.STEAL_STORAGE.TEXT1 ))
 		if not safeUnit:getTraits().W93_safe_spotted then


### PR DESCRIPTION
At ``spottedStorage == 1``, it reinserts two hooks of itself instead of one. I don't think that's intentional and it caused an issue of an extremely long game freeze: https://discord.com/channels/313015356052471828/313015598789427202/1522250446893224068