### PR TITLE
Simplify courier reward logic

### DIFF
--- a/scripts/appended_functions/serverdefs.lua
+++ b/scripts/appended_functions/serverdefs.lua
@@ -158,14 +158,12 @@ serverdefs.createNewSituation = function( campaign, gen, tags, difficulty )
 
 	if not newSituation and array.find(tags, "close_by") then
 		-- Secure Holding Facility/Courier Rescue: if there was no viable location, lift the requirement for proximity.
-		if not array.find(tags, "close_by_nevermind") then
-			table.insert(tags, "close_by_nevermind")
-			newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
-		end
-		if not newSituation and not array.find(tags, "corp_nevermind") then
-			-- Still no viable location. Allow any corp.
+		log:write("[MM] new situation cannot find nearby location, trying any location within corp")
+		array.removeElement(tags, "close_by")
+		newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
+		if not newSituation then
+			log:write("[MM] new situation cannot find any location within corp, trying any location")
 			-- (Presence of corp in the tags list is sufficient, no need to remove any existing corp tag)
-			table.insert(tags, "corp_nevermind")
 			array.concat(tags, serverdefs.CORP_NAMES)
 			newSituation = serverdefs_createNewSituation_old( campaign, gen, tags, difficulty )
 		end
@@ -199,17 +197,15 @@ end
 --SECURE HOLDING FACILITY/COURIER RESCUE
 local serverdefs_defaultMapSelector_old = serverdefs.defaultMapSelector
 serverdefs.defaultMapSelector = function( campaign, tags, tempLocation )
-	if array.find(tags, "close_by") and not array.find(tags, "close_by_nevermind") then
-		local MAX_DIST = 6 -- 6 hour distance
+	if array.find(tags, "close_by") then
+		local MAX_DIST = 6 -- distance in hours
 		local dist = serverdefs.trueCalculateTravelTime( serverdefs.MAP_LOCATIONS[ campaign.location ], tempLocation, campaign )
-		-- log:write(tostring(dist))
+		-- log:write("[MM] testing max-dist against location " .. tempLocation.name .. " - " .. tostring(dist))
 		if dist > MAX_DIST then
 			return false
 		end
 	end
-
 	return serverdefs_defaultMapSelector_old( campaign, tags, tempLocation)
-
 end
 
 end

--- a/scripts/missions/ea_hostage.lua
+++ b/scripts/missions/ea_hostage.lua
@@ -674,23 +674,17 @@ local function startPhase( script, sim )
 	script:waitFor( HOSTAGE_ESCAPED )
 	sim.TA_mission_success = true -- flag for Talkative Agents
 	sim:getTags().EA_hostage_rescued = true
-	--sim:setMissionReward( MISSION_REWARD )
-	-- sim:setMissionReward ( simquery.scaleCredits( sim, MISSION_REWARD ))		--removed for now as we want the two new sites to be the only reward from this.
+	-- sim:setMissionReward( simquery.scaleCredits( sim, MISSION_REWARD )) --removed for now as we want the new sites to be the only reward from this.
 	sim:removeObjective( "hostage_3" )
 
-	-- Spawn two new missions in the same corp but otherwise unspecified
+	-- Spawn new missions in the same corp but otherwise unspecified
 	local serverdefs = include( "modules/serverdefs" )
 	local tags = util.tmerge( { sim:getParams().world, "2max", "close_by", }, serverdefs.ESCAPE_MISSION_TAGS )
-	if array.find( tags, "executive_terminals" ) then
-		array.removeIf( tags, function(v) return v == "executive_terminals" end )
-	end
-	if array.find( tags, "ea_hostage" ) then
-		array.removeIf( tags, function(v) return v == "ea_hostage" end )
-	end
+	array.removeIf(tags, function(v) return v == "executive_terminals" or v == "ea_hostage" end) -- These are not satisfying rewards to the player.
 
-	sim:addNewLocation( tags )
-	sim:addNewLocation( tags )
-	sim:addNewLocation( tags )
+	for i = 1, 3 do
+		sim:addNewLocation(util.tdupe(tags))
+	end
 
 	-- sim:getTags().delayPostGame = true
 	script:waitFrames( 0.5*cdefs.SECONDS )

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -49,10 +49,6 @@ return {
 
 		ASSASSINATION = "ASSASSINATION",
 		ASSASSINATION_TIP = "<c:FF8411>ASSASSINATION</c>\nProvides credits at the cost of a corp-wide security increase. And your conscience.",
-		HOLOSTUDIO = "HOLOSTUDIO",
-		HOLOSTUDIO_TIP = "<c:FF8411>HOLOSTUDIO</c>\nProvides advanced Holo-Projectors. Similiar to Security Dispatch.",
-		LANDFILL = "SALVAGING PLANT",
-		LANDFILL_TIP = "<c:FF8411>SALVAGING PLANT</c>\nProvides disliked items at heavy discounts. Similiar to Nanofab Vestibule.",
 		DISTRESSCALL = "DISTRESS CALL",
 		DISTRESSCALL_TIP = "<c:FF8411>DISTRESS CALL</c>\nProvides a chance at an agent and their gear, but the alarm rises quickly.",
 		WEAPONSEXPO = "TECH EXPO",


### PR DESCRIPTION
This might\* fix #244 

\*Uncertain only because I'm honestly too lazy to try reproducing with the original code.

Tested: Debug spawned one hostage mission per corp and it always found all valid locations before falling back. Verified via new log statements.

If we feel like there are too many remote island locations that break the logic, we could consider changing the fallback to look for any nearby location regardless of corp.