### PR TITLE
Assassination bodyguard tweaks

### DIFF
--- a/scripts/appended_functions/idle.lua
+++ b/scripts/appended_functions/idle.lua
@@ -1,5 +1,30 @@
 local IdleSituation = include("sim/btree/situations/idle")
 
+-- make bodyguard patrol never leave the room with the vip
+-- this is complicated a bit by AGP having a helper with the same name
+-- (I wanted it to work with AGP so he can get the 3 point patrols)
+local wrappedCanPatrolRooms = {}
+while true do
+	local oldCanPatrolRoom, idx, subFn = upvalueUtil.find(IdleSituation.generatePatrolPath, function(name, value)
+		return name == "canPatrolRoom" and type(value) == "function" and not wrappedCanPatrolRooms[value]
+	end, 10)
+	if not idx then
+		break
+	end
+	local function canPatrolRoom(sim, startRoom, room, unit, ...)
+		if type(unit) == "table" and startRoom and unit.getTraits and unit:getTraits().MM_bodyguard then
+			if startRoom == room then
+				return true
+			else
+				return false
+			end
+		end
+		return oldCanPatrolRoom(sim, startRoom, room, unit, ...)
+	end
+	wrappedCanPatrolRooms[canPatrolRoom] = true
+	debug.setupvalue(subFn, idx, canPatrolRoom)
+end
+
 local oldGeneratePatrolPath = IdleSituation.generatePatrolPath
 
 function IdleSituation:generatePatrolPath( unit, x0, y0, noPatrolCheck )

--- a/scripts/appended_functions/pcplayer.lua
+++ b/scripts/appended_functions/pcplayer.lua
@@ -3,24 +3,26 @@ local simquery = include( "sim/simquery" )
 local simplayer = include( "sim/simplayer" )
 local pcplayer = include( "sim/pcplayer" )
 
-local oldOnUnitAdded = pcplayer.onUnitAdded or simplayer.onUnitAdded
-
-function pcplayer:onUnitAdded( unit, ... )
-	oldOnUnitAdded( self, unit, ... )
-
-	local sim = self._sim
-	if sim:getParams().difficultyOptions.mm_enabled then
-		local x0, y0 = unit:getLocation()
-		if x0 and simquery.couldUnitSee( sim, unit ) then
-			-- Send TRG_LOS_REFRESH for all cells seen by the unit.
-			-- sim:refreshUnitLOS only triggers with cells that the unit couldn't see before, but all visible cells might be "new" to the updated player.
-			local cells = sim._los:calculateUnitLOS( sim:getCell( x0, y0 ), unit )
-			coords = {}
-			for _,cell in pairs( cells ) do
-				table.insert( coords, cell.x )
-				table.insert( coords, cell.y )
+if not mod_manager.isVersionInstalled or not mod_manager:isVersionInstalled("Community Bug Fixes", "1.20.0") then
+	local oldOnUnitAdded = pcplayer.onUnitAdded or simplayer.onUnitAdded
+	
+	function pcplayer:onUnitAdded( unit, ... )
+		oldOnUnitAdded( self, unit, ... )
+	
+		local sim = self._sim
+		if sim:getParams().difficultyOptions.mm_enabled then
+			local x0, y0 = unit:getLocation()
+			if x0 and simquery.couldUnitSee( sim, unit ) then
+				-- Send TRG_LOS_REFRESH for all cells seen by the unit.
+				-- sim:refreshUnitLOS only triggers with cells that the unit couldn't see before, but all visible cells might be "new" to the updated player.
+				local cells = sim._los:calculateUnitLOS( sim:getCell( x0, y0 ), unit )
+				coords = {}
+				for _,cell in pairs( cells ) do
+					table.insert( coords, cell.x )
+					table.insert( coords, cell.y )
+				end
+				sim:triggerEvent( simdefs.TRG_LOS_REFRESH, { seer = unit, cells = coords } )
 			end
-			sim:triggerEvent( simdefs.TRG_LOS_REFRESH, { seer = unit, cells = coords } )
 		end
 	end
 end

--- a/scripts/btree/actions.lua
+++ b/scripts/btree/actions.lua
@@ -24,7 +24,10 @@ function Actions.mmArmVip( sim, unit )
 	local currentInterest = unit:getBrain():getInterest()
 	if currentInterest and interestOutsideOfSaferoom( sim, currentInterest ) then
 		sim:dispatchEvent( simdefs.EV_UNIT_DEL_INTEREST, {unit = unit, interest = currentInterest} )
-		sim:triggerEvent( simdefs.TRG_DEL_INTEREST, {unit = unit, interest = currentInterest} )
+		-- this can actually delete other unit's interests that they were about to investigate
+		-- only do this for interests that have actually been investigated (interest1.investigated ~= interest2.investigated)
+		-- sim:triggerEvent( simdefs.TRG_DEL_INTEREST, {unit = unit, interest = currentInterest} )
+		unit:getBrain():getSenses():removeInterest(currentInterest)
 	end
 	-- Remove other interests outside the saferoom
 	array.removeIf( unit:getBrain():getSenses().interests, function( interest ) return interestOutsideOfSaferoom( sim, interest ) end )

--- a/scripts/escape_mission.lua
+++ b/scripts/escape_mission.lua
@@ -152,7 +152,7 @@ local function PC_SAW_UNIT_WITH_MARKER2( script, tag, marker )
 	{
 		trigger = simdefs.TRG_UNIT_APPEARED,
 		fn = function( sim, evData )
-			local seer = sim:getUnit( evData.seerID )
+			local seer = sim:getPlayerByID(evData.seerID)
 			if not seer or not seer:isPC() then
 				return false
 			end

--- a/scripts/guarddefs.lua
+++ b/scripts/guarddefs.lua
@@ -206,7 +206,6 @@ local npc_templates =
 			kill_trigger = "guard_dead",
 			vip = true, --This flag is important for the panic behaviour
 			pacifist = true,
-			recap_icon = "executive",
 			MM_bounty_target = true,
 			MM_alertlink = true,
 			mm_fixnopatrolfacing = true,
@@ -223,7 +222,7 @@ local npc_templates =
 		abilities = {"shootOverwatch", "overwatch", "MM_fakesteal"},
 		children = {},
 		idles = DEFAULT_IDLES,
-		sounds = DROID_SOUNDS,
+		sounds = SOUNDS.GUARD,
 		brain = "mmBountyFakeBrain",
 	},
 
@@ -305,6 +304,7 @@ local npc_templates =
 			dashSoundRange = 8,
 			sightable = true,
 			woundsMax = 2,
+			always_patrol = true,
 			MM_bodyguard = true,
 			MM_alertlink = true,
 			recap_icon = "executive",

--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -15,13 +15,6 @@ local SCRIPTS = include("client/story_scripts")
 
 local CHANCE_OF_DECOY = 0.3
 
-local function queueCentral(script, scripts)
-	for k, v in pairs(scripts) do
-		script:queue( { script=v, type="newOperatorMessage" } )
-		script:queue(0.5*cdefs.SECONDS)
-	end	
-end
-
 ----
 -- Trigger Definitions
 

--- a/scripts/missions/assassination.lua
+++ b/scripts/missions/assassination.lua
@@ -1,4 +1,3 @@
-local array = include( "modules/array" )
 local binops = include( "modules/binary_ops" )
 local util = include( "modules/util" )
 local cdefs = include( "client_defs" )
@@ -10,14 +9,11 @@ local simquery = include( "sim/simquery" )
 local mission_util = include( "sim/missions/mission_util" )
 local escape_mission = include( "sim/missions/escape_mission" )
 local SCRIPTS = include("client/story_scripts")
-local mathutil = include( "modules/mathutil" )
 
 ---------------------------------------------------------------------------------------------
 -- Local helpers
 
 local CHANCE_OF_DECOY = 0.3
-local bodyguard_unit --file-wide variable for ease of checking
-local bounty_target_unit
 
 local function queueCentral(script, scripts)
 	for k, v in pairs(scripts) do
@@ -47,29 +43,15 @@ local DECOY_REVEALED =
 	end,
 }
 
-local NEW_INTEREST = 
-{
-	trigger = simdefs.TRG_NEW_INTEREST,
-	fn = function( sim, evData )
-		if evData.interest.sourceUnit and evData.interest.sourceUnit:getTraits().MM_bounty_target and not evData.interest.sourceUnit:getTraits().MM_realtarget then
-			if evData.interest.reason == nil or (evData.interest.reason and not (evData.interest.reason == "REASON_MM_ASSASSINATION") ) then
-				return evData.interest
-			end
-		end
-	end,
-}
-
-local NEW_UNIT_INTEREST = 
-{
+local NEW_VIP_INTEREST = {
 	trigger = simdefs.TRG_UNIT_NEWINTEREST,
-	fn = function( sim, evData )
-		if evData.unit and evData.unit:getTraits().MM_bounty_target and not evData.unit:getTraits().MM_realtarget then
-			if evData.interest.reason == nil or (evData.interest.reason and not (evData.interest.reason == "REASON_MM_ASSASSINATION")) then
-				local interest = { sourceUnit = evData.unit, x = evData.interest.x, y = evData.interest.y }
-				-- log:write("[MM] interest")
-				-- log:write(util.stringize(evData.unit:getUnitData().name,2))
-				return interest
-			end
+	fn = function(sim, evData)
+		if
+			evData.unit:getTraits().MM_bounty_target
+			and not evData.unit:getTraits().MM_realtarget
+			and evData.interest.reason ~= "REASON_MM_ASSASSINATION"
+		then
+			return evData.unit, evData.interest
 		end
 	end,
 }
@@ -163,129 +145,53 @@ local BODYGUARD_KO =
 	end,
 }
 
-local BODYGUARD_SHOT_AT =
-{
-	trigger = "MM_shotAtBodyguard",
-	fn = function( sim, evData )
-		if evData.targetUnit:getTraits().MM_bodyguard then
-			local equipped = evData.equipped
-			if equipped and not (equipped:getTraits().canSleep or equipped:getTraits().targetNotAlerted or equipped:getTraits().noTargetAlert) then
-				-- log:write("[MM] trigger MM_shotAtBodyguard")
-				return evData.targetUnit, evData.sourceUnit
-			end
-		end
-	end,
-}
-
-local UNIT_WARP = 
-{
-	trigger = simdefs.TRG_UNIT_WARP,
-	fn = function( sim, evData )
-		return evData.unit
-	end
-}
-
-local UNIT_USE_DOOR = 
-{
-	trigger = simdefs.TRG_UNIT_USEDOOR,
-	fn = function( sim, evData )
-		return evData.unit
-	end
-}
-
--- this is a mishmash of PC_SAW_UNIT and PC_SAW_CELL_WITH_TAG, as the former doesn't work when a player-captured camera spots the VIP.
-PC_SAW_UNIT_FIXED = function( tag )
-	return
-	{
-		trigger = simdefs.TRG_LOS_REFRESH,
-		fn = function( sim, evData )
-			local seer =  evData.seer 
+local PC_SAW_UNIT_FIXED = function(tag)
+	return {
+		trigger = simdefs.TRG_UNIT_APPEARED,
+		fn = function(sim, evData)
+			local seer = sim:getPlayerByID(evData.seerID)
 			if not seer or not seer:isPC() then
 				return false
 			end
-			
-			for i = 1, #evData.cells, 2 do
-				local cell = sim:getCell(evData.cells[i],evData.cells[i+1])		
-				if cell.units then
-					for i, seenUnit in pairs(cell.units) do
-						if seenUnit:hasTag(tag) then
-							return seenUnit, seer
+
+			if not tag or evData.unit:hasTag(tag) then
+				local x, y = evData.unit:getLocation()
+				if x then
+					for _, seerUnit in ipairs(seer:getUnits()) do
+						-- don't use sim:canUnitSeeUnit or unit:getSeenUnits
+						-- sim:notifySeers updates units after players so they are not updated yet
+						-- (sim:refreshUnitLOS does it in reverse order...)
+						if sim:canUnitSee(seerUnit, x, y) and simquery.couldUnitSee(sim, seerUnit, evData.unit) then
+							return evData.unit, seerUnit
 						end
 					end
-				end		
+				end
 			end
-
 			return false
 		end,
 	}
 end
 
--- bodyguard behaviour: keeping within vision range of VIP, investigating in his stead
-local function keepClose( script, sim )
+-- when VIP is distracted, bodyguard investigates distraction instead if in sight, while VIP investigates on the spot
+local function waitForUnitInterest(script, sim)
 	while true do
+		local _, vip, interest = script:waitFor(NEW_VIP_INTEREST)
 		local bodyguard = nil
-		local vip = nil
-		script:waitFor( mission_util.PC_START_TURN )
 		for i, unit in pairs(sim:getNPC():getUnits()) do
-			if unit:getTraits().MM_bodyguard then
+			if unit:getTraits().MM_bodyguard and unit:getBrain() and not unit:isKO() then
 				bodyguard = unit
 			end
-			if sim.MM_bounty_disguise_active then
-				if unit:getTraits().MM_decoy then
-					vip = unit
-				end
-			else
-				if unit:getTraits().MM_bounty_target then
-					vip = unit
-				end
+		end
+		if bodyguard then
+			local x0, y0 = vip:getLocation()
+			if not vip:getTraits().MM_ceo_armed and simquery.couldUnitSeeCell(sim, bodyguard, sim:getCell(x0, y0)) then
+				vip:getBrain():getSenses():addInterest(x0, y0, interest.sense, "REASON_MM_ASSASSINATION") --vip stays put and investigates in place
+				bodyguard
+					:getBrain()
+					:getSenses()
+					:addInterest(interest.x, interest.y, simdefs.SENSE_RADIO, interest.reason, interest.sourceUnit) --bodyguard investigates distraction
 			end
 		end
-		if bodyguard and vip and bodyguard:getBrain() and not bodyguard:isKO() then
-			if not simquery.couldUnitSeeCell( sim, bodyguard, sim:getCell(vip:getLocation()) ) and not (bodyguard:getTraits().lostVIP or bodyguard:getTraits().previouslyLostVIP) then
-				bodyguard:getTraits().previouslyLostVIP = nil
-				local x1,y1 = vip:getLocation()
-				bodyguard:getBrain():spawnInterest(x1, y1, simdefs.SENSE_RADIO, simdefs.REASON_NOTICED, vip) -- give persistent interest point to VIP's location
-				bodyguard:getTraits().lostVIP = true
-			elseif simquery.couldUnitSeeCell( sim, bodyguard, sim:getCell(vip:getLocation()) ) and bodyguard:getTraits().lostVIP then
-				bodyguard:getTraits().lostVIP = nil
-				bodyguard:getTraits().previouslyLostVIP = true
-				local x1,y1 = vip:getLocation()
-				bodyguard:getBrain():spawnInterest(x1, y1, simdefs.SENSE_RADIO, simdefs.REASON_NOTICED, vip) 		
-			end
-		end
-	end
-end
-
--- when VIP is distracted, bodyguard investigates distraction instead if in sight, while VIP investigates on the spot
-local function transferInterest( sim, interest )
-	local bodyguard = nil
-	local vip = interest.sourceUnit
-	for i, unit in pairs(sim:getNPC():getUnits()) do
-		if unit:getTraits().MM_bodyguard and unit:getBrain() and not unit:isKO() then
-			bodyguard = unit
-		end
-	end
-	if bodyguard and vip and not vip:getTraits().MM_ceo_armed and (simquery.couldUnitSeeCell( sim, bodyguard, sim:getCell(vip:getLocation()) ) or sim.MM_bounty_disguise_active ) then
-		local x0, y0 = vip:getLocation()
-		local x1, y1 = interest.x, interest.y
-		vip:getBrain():spawnInterest(x0,y0, sim:getDefs().SENSE_DEBUG, "REASON_MM_ASSASSINATION") --vip stays put and investigates in place	
-		if simquery.couldUnitSeeCell( sim, bodyguard, sim:getCell(vip:getLocation()) ) then
-			bodyguard:getBrain():spawnInterest(x1,y1, simdefs.SENSE_RADIO, "REASON_MM_ASSASSINATION") --bodyguard investigates distraction
-		end
-	end
-end
-
-local function waitForInterest( script, sim )
-	while true do
-		local _, interest = script:waitFor( NEW_INTEREST )
-		transferInterest( sim, interest)	
-	end
-end
-
-local function waitForUnitInterest( script, sim )
-	while true do
-		local _, interest = script:waitFor( NEW_UNIT_INTEREST )
-		transferInterest( sim, interest)		
 	end
 end
 
@@ -328,20 +234,6 @@ local PC_UNLOCK_SAFEROOM_START_TURN =
 	trigger = simdefs.TRG_START_TURN,
 	fn = function( sim, evData )
 		return evData:isPC() and playerCanUnlockSaferoom( sim )
-	end,
-}
-local ESCAPE_WITH_BODY =
-{
-	trigger = simdefs.TRG_UNIT_ESCAPED,
-	fn = function( sim, triggerData )
-		for unitID, unit in pairs(sim:getAllUnits()) do
-			if unit:hasTag("assassination") then
-				local cell = sim:getCell( unit:getLocation() )
-				if cell and cell.exitID == simdefs.DEFAULT_EXITID then
-					return unit
-				end
-			end
-		end
 	end,
 }
 ----
@@ -768,8 +660,6 @@ local function ceoAlerted(script, sim, mission)
 	ceo:getTraits().MM_alertlink = nil
 
 	-- remove these hooks, as we don't want the bodyguard trying to do these things while the CEO is in the panic room
-	script:removeHook(keepClose)
-	script:removeHook(waitForInterest)
 	script:removeHook(waitForUnitInterest)
 	
 	-- Alert the bodyguard, unless we have already sent an alert
@@ -834,43 +724,6 @@ local function despawnRedundantCameraDB(sim)
 	end
 end
 
--- Like turnToFace, but without processReactions
-local function turnBodyguardToFace(self, x, y)
-	if self:getTraits().refreshingLOS then
-		return
-	end
-	
-	local x1, y1 = self:getLocation()
-	local facing = simquery.getDirectionFromDelta(x - x1, y - y1)
-
-	if facing >= 0 and facing < simdefs.DIR_MAX and self._facing ~= facing then
-		--self:resetAllAiming()
-		self:getTraits().turning = true
-		self._facing = facing
-		self._sim:dispatchEvent( simdefs.EV_UNIT_TURN, { unit = self, facing = facing } )
-
-		if self:isValid() and self:hasTrait("hasSight") then
-			self._sim:refreshUnitLOS( self )
-		end
-		--if self:getPlayerOwner():isNPC() then
-		--	self._sim:processReactions(self)
-		--end
-		self:getTraits().turning = nil
-	end
-end
-
-local function bodyguardShotAt( script, sim )
-	local _, guard, agent = script:waitFor( BODYGUARD_SHOT_AT )
-	if guard:isValid() and guard:getLocation() and not guard:isKO() then
-		if simquery.couldUnitSee( sim, guard, agent, true, nil ) then
-			--guard:turnToFace( agent:getLocation() )
-			turnBodyguardToFace( guard, agent:getLocation() )
-		end
-	end
-
-	script:addHook( bodyguardShotAt )
-end
-
 local function waitForSteal( script, sim, mission )
 	local _, decoy = script:waitFor( TRIED_TO_STEAL_FROM_DECOY )
 	mission.revealDecoy( sim, decoy )
@@ -885,7 +738,7 @@ local function despawnDecoy( script, sim )
 	end
 	
 	script:queue( { type="hideHUDInstruction" } ) 
-	script:waitFor( mission_util.PC_ANY, PC_AFTER_ANY )
+	script:waitFor( mission_util.PC_ANY, PC_AFTER_ANY, mission_util.PC_START_TURN )
 	sim:warpUnit( decoyUnit, nil ) -- remove the original
 	sim:despawnUnit( decoyUnit ) 
 	
@@ -899,19 +752,18 @@ local function despawnDecoy( script, sim )
 	end
 end
 
-local 	PC_WON =
-	{		
-        priority = 10,
+--[[ local PC_WON = {
+	priority = 10,
 
-        trigger = simdefs.TRG_GAME_OVER,
-        fn = function( sim, evData )
-            if sim:getWinner() then
-                return sim:getPlayers()[sim:getWinner()]:isPC()
-            else
-                return false
-            end
-        end,
-	}
+	trigger = simdefs.TRG_GAME_OVER,
+	fn = function(sim, evData)
+		if sim:getWinner() then
+			return sim:getPlayers()[sim:getWinner()]:isPC()
+		else
+			return false
+		end
+	end,
+} ]]
 
 -- local function updateAgency( script, sim, mission ) --UNUSED
 	-- script:waitFor( PC_WON )
@@ -1015,7 +867,6 @@ end
 local function tryDecoy( sim )
 	-- log:write("[MM] trying decoy")
 	local vip = nil -- resetting for save file edge cases
-	local no_decoy = nil
 	-- if sim:getParams().agency.MM_assassinations == nil then
 		-- no_decoy = true -- guarantee no decoy on first campaign assassination
 	-- end
@@ -1086,10 +937,7 @@ function mission:init( scriptMgr, sim )
 	scriptMgr:addHook( "UNLOCK", playerUnlocksSaferoom, nil, self )
 	scriptMgr:addHook( "BODYGUARD", bodyguardAlertsCeo, nil, self )
 	scriptMgr:addHook( "CEO", ceoAlerted, nil, self )
-	scriptMgr:addHook( "bodyguardShotAt", bodyguardShotAt )
-	scriptMgr:addHook( "waitForInterest", waitForInterest )
 	scriptMgr:addHook( "waitForUnitInterest", waitForUnitInterest )
-	scriptMgr:addHook( "keepClose", keepClose )
 	scriptMgr:addHook( "SEE_REAL", playerSeesRealCEO, nil, self )
 	scriptMgr:addHook( "waitForSteal", waitForSteal, nil, self )
 	scriptMgr:addHook( "despawnDecoy", despawnDecoy )


### PR DESCRIPTION
The main change is that the bodyguard no longer gets an interest if he is out of vision range of the VIP (which also triggered every time his normal patrol made him leave VIP vision) but instead always gets a patrol that doesn't leave the room. I also gave him the ``always_patrol`` trait because I think both the VIP and the bodyguard being stationary is weird and it's cooler to have the bodyguard patrol around him.
The other slight change is that the decoy also requires the bodyguard being in range to ignore interests now. Previously I think this was a thing so he doesn't move that easily and reveal that he is a decoy with his walk sound. So I changed the decoy's walk sound to the default VIP sounds, too.
Oh, and for the decoy despawn hook I added ``PC_START_TURN`` because it was annoying how until the first player action there were both the decoy and the android on the same tile (the player could see both observe tabs)

Then there are two bug fixes:
The previous ``PC_SAW_UNIT_FIXED`` didn't work when the VIP entered the vision of a hacked camera
The VIP reaching his safe and triggering ``TRG_DEL_INTEREST`` was able to remove interests from other guards and change their destination mid-turn

The rest is mostly just cleanup of unused code. The bodyguard apparently had a trigger that made him turn around if he gets shot? Why? If it's for the dermal armor then that's something Function Library already addresses (although I want to propose some improvements to this to Wodzu)