### PR TITLE
Fix Androids' inventory being visible/usable while hacked

### DIFF
--- a/scripts/guarddefs.lua
+++ b/scripts/guarddefs.lua
@@ -91,6 +91,10 @@ local ANDROID_TRAITS = util.extend( commondefs.basic_agent_traits )
 	lookaroundRange = 5,
 }
 
+-- drones (basic_robot_traits) don't have this so the inventory doesn't show when hacked
+-- (this could make goose ops able to throw buster chips with EAA)
+ANDROID_TRAITS.inventoryMaxSize = nil
+
 local SPECDROID_TRAITS = util.extend( ANDROID_TRAITS )
 {
 	-- walk=true,


### PR DESCRIPTION
The Androids' traits are extended from agent traits instead of the robot traits so it has ``inventoryMaxSize`` which makes the UI able to show the inventory while hacked.
Maybe it should be changed to extend from ``basic_robot_traits`` instead so it also has stuff like ``canBeFriendlyShot`` but I guess it's too late for that. So the fix is to simply remove the ``inventoryMaxSize`` trait.